### PR TITLE
Exception Handler 추가

### DIFF
--- a/src/main/java/com/techeer/f5/jmtmonster/domain/hello/controller/HelloController.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/hello/controller/HelloController.java
@@ -1,0 +1,40 @@
+package com.techeer.f5.jmtmonster.domain.hello.controller;
+
+import com.techeer.f5.jmtmonster.domain.hello.dto.HelloRequestDto;
+import com.techeer.f5.jmtmonster.domain.hello.dto.HelloResponseDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/hello")
+public class HelloController {
+
+    @GetMapping
+    public ResponseEntity<HelloResponseDto> get() {
+
+        HelloResponseDto response = HelloResponseDto.builder()
+                .value("hello")
+                .success(true)
+                .build();
+
+        return ResponseEntity.ok()
+                .body(response);
+    }
+
+    @PostMapping
+    public ResponseEntity<HelloResponseDto> create(@Validated @RequestBody HelloRequestDto dto) {
+
+        HelloResponseDto response = HelloResponseDto.builder()
+                .value("hello " + dto.getStringValue() + dto.getIntValue())
+                .success(true)
+                .build();
+
+        return ResponseEntity.ok()
+                .body(response);
+    }
+}

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/hello/dto/HelloRequestDto.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/hello/dto/HelloRequestDto.java
@@ -1,0 +1,22 @@
+package com.techeer.f5.jmtmonster.domain.hello.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class HelloRequestDto {
+
+    @NotEmpty
+    private String stringValue;
+
+    @NotNull
+    private Long intValue;
+}

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/hello/dto/HelloResponseDto.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/hello/dto/HelloResponseDto.java
@@ -1,0 +1,21 @@
+package com.techeer.f5.jmtmonster.domain.hello.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class HelloResponseDto {
+
+    private String value;
+    private boolean success;
+
+    @Builder.Default
+    private LocalDateTime createdOn = LocalDateTime.now();
+}

--- a/src/main/java/com/techeer/f5/jmtmonster/global/error/ErrorResponse.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/global/error/ErrorResponse.java
@@ -1,0 +1,74 @@
+package com.techeer.f5.jmtmonster.global.error;
+
+import com.techeer.f5.jmtmonster.global.error.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Setter
+@Getter
+public class ErrorResponse {
+
+    private String code;
+
+    private String message;
+
+    private List<CustomFieldError> errors;
+
+    private LocalDateTime timestamp = LocalDateTime.now();
+
+    private ErrorResponse(ErrorCode errorCode, String message, List<FieldError> errors) {
+        setErrorCode(errorCode);
+        setMessage(message);
+        this.errors = errors.stream().map(CustomFieldError::new).collect(Collectors.toList());
+    }
+
+    private ErrorResponse(ErrorCode errorCode, String message, String exceptionMessage) {
+        setErrorCode(errorCode);
+        setMessage(message);
+        this.errors = List.of(new CustomFieldError("", "", exceptionMessage));
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, String message) {
+        return new ErrorResponse(errorCode, message, Collections.emptyList());
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, String message, BindingResult bindingResult) {
+        return new ErrorResponse(errorCode, message, bindingResult.getFieldErrors());
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, String message, String exceptionMessage) {
+        return new ErrorResponse(errorCode, message, exceptionMessage);
+    }
+
+    private void setErrorCode(ErrorCode errorCode) {
+        this.code = errorCode.getCode();
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class CustomFieldError {
+
+        private String field;
+        private String value;
+        private String reason;
+
+        private CustomFieldError(FieldError fieldError) {
+            this.field = fieldError.getField();
+
+            if (fieldError.getRejectedValue() != null) {
+                this.value = fieldError.getRejectedValue().toString();
+            } else {
+                this.value = "";
+            }
+            this.reason = fieldError.getDefaultMessage();
+        }
+    }
+}

--- a/src/main/java/com/techeer/f5/jmtmonster/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,122 @@
+package com.techeer.f5.jmtmonster.global.error;
+
+import com.techeer.f5.jmtmonster.global.error.exception.CustomStatusException;
+import com.techeer.f5.jmtmonster.global.error.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.validation.BindException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@Slf4j
+@ControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatus status, WebRequest request) {
+        log.error("handleMethodArgumentNotValidException {}", ex.getMessage());
+
+        ErrorCode errorCode = ErrorCode.BAD_REQUEST;
+        final ErrorResponse response = ErrorResponse.of(errorCode, errorCode.getCode(), ex.getBindingResult());
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleBindException(BindException ex, HttpHeaders headers, HttpStatus status, WebRequest request) {
+        log.error("handleBindException {}", ex.getMessage());
+
+        ErrorCode errorCode = ErrorCode.INVALID_INPUT_VALUE;
+        final ErrorResponse response = ErrorResponse.of(errorCode, errorCode.getCode(), ex.getBindingResult());
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        log.error("handleMethodArgumentTypeMismatchException {}", e.getMessage());
+
+        ErrorCode errorCode = ErrorCode.INVALID_INPUT_VALUE;
+        final ErrorResponse response = ErrorResponse.of(errorCode, errorCode.getCode());
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleNoHandlerFoundException(NoHandlerFoundException ex, HttpHeaders headers, HttpStatus status, WebRequest request) {
+        log.error("handleNoHandlerFoundException {}", ex.getMessage());
+
+        ErrorCode errorCode = ErrorCode.NOT_FOUND;
+        final ErrorResponse response = ErrorResponse.of(errorCode, errorCode.getCode());
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleHttpRequestMethodNotSupported(HttpRequestMethodNotSupportedException ex, HttpHeaders headers, HttpStatus status, WebRequest request) {
+        log.error("handleHttpRequestMethodNotSupportedException {}", ex.getMessage());
+
+        ErrorCode errorCode = ErrorCode.METHOD_NOT_ALLOWED;
+        final ErrorResponse response = ErrorResponse.of(errorCode, errorCode.getCode());
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    protected ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException e) {
+        log.error("handleAccessDeniedException {}", e.getMessage());
+
+        ErrorCode errorCode = ErrorCode.ACCESS_DENIED;
+        final ErrorResponse response = ErrorResponse.of(errorCode, errorCode.getCode());
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    protected ResponseEntity<ErrorResponse> handleIllegalStatementException(IllegalStateException e) {
+        log.error("handleIllegalStateException {}", e.getMessage());
+
+        ErrorCode errorCode = ErrorCode.ILLEGAL_STATE;
+        final ErrorResponse response = ErrorResponse.of(errorCode, errorCode.getCode(), e.getMessage());
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    protected ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
+        log.error("handleIllegalArgumentException {}", e.getMessage());
+
+        ErrorCode errorCode = ErrorCode.ILLEGAL_ARGUMENT;
+        final ErrorResponse response = ErrorResponse.of(errorCode, errorCode.getCode(), e.getMessage());
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+
+    protected ResponseEntity<Object> handleHttpMessageNotReadable(HttpMessageNotReadableException ex, HttpHeaders headers, HttpStatus status, WebRequest request) {
+        log.error("handleHttpMessageNotReadable {}", ex.getMessage());
+
+        ErrorCode errorCode = ErrorCode.INVALID_JSON_FORMAT;
+        final ErrorResponse response = ErrorResponse.of(errorCode, "Invalid JSON format.");
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+
+    @ExceptionHandler(CustomStatusException.class)
+    protected ResponseEntity<ErrorResponse> handleCustomStatusException(CustomStatusException e, WebRequest request) {
+        log.error("handleCustomStatusException {}", e.getMessage());
+
+        ErrorCode errorCode = e.getCode();
+        final ErrorResponse response = ErrorResponse.of(errorCode, errorCode.getCode(), e.getMessage());
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("handleException {}", e.getMessage());
+
+        ErrorCode errorCode = ErrorCode.EXCEPTION;
+        final ErrorResponse response = ErrorResponse.of(errorCode, errorCode.getCode(), e.getMessage());
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+}

--- a/src/main/java/com/techeer/f5/jmtmonster/global/error/exception/CustomStatusException.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/global/error/exception/CustomStatusException.java
@@ -1,0 +1,16 @@
+package com.techeer.f5.jmtmonster.global.error.exception;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class CustomStatusException extends RuntimeException {
+
+    private final ErrorCode code;
+
+    public CustomStatusException(ErrorCode code, String message) {
+        super(message);
+        this.code = code;
+    }
+}

--- a/src/main/java/com/techeer/f5/jmtmonster/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/global/error/exception/ErrorCode.java
@@ -1,0 +1,24 @@
+package com.techeer.f5.jmtmonster.global.error.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    NOT_FOUND(HttpStatus.NOT_FOUND, "NOT_FOUND"),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "BAD_REQUEST"),
+    INVALID_JSON_FORMAT(HttpStatus.BAD_REQUEST, "INVALID_JSON_FORMAT"),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "INVALID_INPUT_VALUE"),
+    ILLEGAL_ARGUMENT(HttpStatus.BAD_REQUEST, "ILLEGAL_ARGUMENT"),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "METHOD_NOT_ALLOWED"),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "ACCESS_DENIED"),
+    ILLEGAL_STATE(HttpStatus.BAD_REQUEST, "ILLEGAL_STATE"),
+    EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "EXCEPTION"),
+            ;
+
+    private final HttpStatus status;
+    private final String code;
+}

--- a/src/main/java/com/techeer/f5/jmtmonster/global/error/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/global/error/exception/ResourceNotFoundException.java
@@ -1,0 +1,14 @@
+package com.techeer.f5.jmtmonster.global.error.exception;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class ResourceNotFoundException extends CustomStatusException {
+
+    public ResourceNotFoundException(String resourceName, String fieldName, Object value) {
+
+        super(ErrorCode.NOT_FOUND, resourceName + " not found with " + fieldName + "=" + value.toString());
+    }
+}


### PR DESCRIPTION
- `global.error` 패키지 추가 (Exception/Error Handling 관련 패키지)
  - `global.error.GlobalExceptionHandler.java`: `ResponseEntityExceptionHandler`을 상속하여, 애플리케이션에서 Exception 발생시 exception을 불러와 처리를 진행합니다.
  - `global.error.ErrorResponse.java`: 에러 DTO
- `global.error.exception` 패키지 추가 (Exception 모음)
  - `global.error.exception.ErrorCode.java`: 에러 코드 포함 (에러 코드 포맷에 관해서는 어떤 것이 좋을지 고민이 필요합니다. 현재는 단순히 `BAD_REQUEST` 이런 식으로 했는데, `JME-001` 등 다른 방식도 있을 것 같습니다!)
  - `global.error.exception.CustomStatusException.java`: message와 ErrorCode를 받아 만드는 개발자가 직접 만들 수 있는 Exception 입니다. 상속해서 abstract class로 할지 고민하다가 일단 일반 class로 두었습니다. 일반적으로 이 클래스를 상속하셔서 필요한 Exception을 만드시면 됩니다. (e.g., `UserNotFoundException`)
  - `global.error.exception.ResourceNotFoundException.java`: `@PathVariable` 로 받은 변수에 대해 자원이 존재하지 않을 경우 404 에러를 위한 Exception

현재 Exception 관련한 테스트 코드 작성은 진행하지 않았기 때문에, 정상적으로 작동하는지, 올바른 에러 포맷에 대한 고민 등은 개발하면서 좀 더 조율할 수 있을 것 같아요!

Resolves #11.