### PR TITLE
Jackson LocalDateTime 매핑 해결, 카멜 케이스 변환, Spring REST Docs & Swagger 연동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ out/
 /src/main/resources/secret.yml
 
 application-secret.yml
+
+target

--- a/build.gradle
+++ b/build.gradle
@@ -65,9 +65,5 @@ openapi3 {
     description = 'Interactive Dining Review Game'
     version = '0.1.0'
     format = 'json'
-
-    copy {
-        from 'build/api-spec'
-        into 'src/main/resources/static/docs'
-    }
+    outputDirectory = 'src/main/resources/static/docs'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation 'org.flywaydb:flyway-core'
     implementation 'com.fasterxml.jackson.core:jackson-core:2.13.2'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.2'
+    implementation 'org.projectlombok:lombok:1.18.22'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'org.springframework.boot' version '2.6.6'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'org.asciidoctor.convert' version '1.5.8'
+    id 'com.epages.restdocs-api-spec' version '0.16.0'
     id 'java'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.16.0'
 }
 
 tasks.named('test') {
@@ -54,4 +55,19 @@ tasks.named('test') {
 tasks.named('asciidoctor') {
     inputs.dir snippetsDir
     dependsOn test
+}
+
+// ./gradlew openapi3
+// See /build/api-spec/openapi3.json
+openapi3 {
+    server = 'http://localhost:8000'
+    title = 'JMT Monster'
+    description = 'Interactive Dining Review Game'
+    version = '0.1.0'
+    format = 'json'
+
+    copy {
+        from 'build/api-spec'
+        into 'src/main/resources/static/docs'
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ tasks.named('asciidoctor') {
 }
 
 // ./gradlew openapi3
-// See /build/api-spec/openapi3.json
+// See /src/main/resources/static/docs/openapi3.json
 openapi3 {
     server = 'http://localhost:8000'
     title = 'JMT Monster'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.3"
+
+services:
+  swagger-ui:
+    image: swaggerapi/swagger-ui:latest
+    ports:
+      - "8001:8080"
+    environment:
+      # 프론트엔드에서만 다루는 URL이기 때문에 host.docker.internal이 아닌 localhost 사용
+      - API_URL=http://localhost:8000/docs/openapi3.json
+    tty: true

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/hello/controller/HelloController.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/hello/controller/HelloController.java
@@ -2,7 +2,6 @@ package com.techeer.f5.jmtmonster.domain.hello.controller;
 
 import com.techeer.f5.jmtmonster.domain.hello.dto.HelloRequestDto;
 import com.techeer.f5.jmtmonster.domain.hello.dto.HelloResponseDto;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -35,7 +34,7 @@ public class HelloController {
                 .success(true)
                 .build();
 
-        return ResponseEntity.status(HttpStatus.CREATED)
+        return ResponseEntity.ok()
                 .body(response);
     }
 }

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/hello/controller/HelloController.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/hello/controller/HelloController.java
@@ -2,6 +2,7 @@ package com.techeer.f5.jmtmonster.domain.hello.controller;
 
 import com.techeer.f5.jmtmonster.domain.hello.dto.HelloRequestDto;
 import com.techeer.f5.jmtmonster.domain.hello.dto.HelloResponseDto;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -34,7 +35,7 @@ public class HelloController {
                 .success(true)
                 .build();
 
-        return ResponseEntity.ok()
+        return ResponseEntity.status(HttpStatus.CREATED)
                 .body(response);
     }
 }

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/oauth/domain/PersistentToken.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/oauth/domain/PersistentToken.java
@@ -28,6 +28,7 @@ public class PersistentToken {
 
     @Enumerated(EnumType.STRING)
     @NotNull
+    @Builder.Default
     private AuthProvider provider = AuthProvider.NONE;
 
     @ManyToOne

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/user/domain/User.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/user/domain/User.java
@@ -40,15 +40,18 @@ public class User {
 
     @Size(min = 1, max = 3, message = "이메일 길이는 1자부터 30자까지 가능합니다.")
     @Nullable
+    @Builder.Default
     private String nickname = null;
 
 
     @Size(min = 1, max = 1024, message = "주소 길이는 1자부터 1024자까지 가능합니다.")
     @Nullable
+    @Builder.Default
     private String address = null;
 
     @Size(min = 1, max = 4096, message = "이미지 주소 길이는 1자부터 1024자까지 가능합니다.")
     @Nullable
+    @Builder.Default
     private String imageUrl = null;
 
     @NotNull

--- a/src/main/java/com/techeer/f5/jmtmonster/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/global/config/RestTemplateConfig.java
@@ -1,9 +1,7 @@
 package com.techeer.f5.jmtmonster.global.config;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -30,7 +28,11 @@ public class RestTemplateConfig {
     @Bean
     public ObjectMapper jacksonObjectMapper()
     {
-        return new ObjectMapper().setPropertyNamingStrategy(propertyNamingStrategy()).configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+        return new ObjectMapper()
+                    .setPropertyNamingStrategy(propertyNamingStrategy())
+                    .configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true)
+                    .registerModule(new JavaTimeModule())
+                    .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     }
 
     @Bean

--- a/src/main/java/com/techeer/f5/jmtmonster/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/global/config/RestTemplateConfig.java
@@ -4,15 +4,10 @@ import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.client.ClientHttpRequest;
-import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 
-import java.io.IOException;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -38,7 +33,7 @@ public class RestTemplateConfig {
     @Bean
     public PropertyNamingStrategy propertyNamingStrategy()
     {
-        return PropertyNamingStrategies.SNAKE_CASE;
+        return PropertyNamingStrategies.LOWER_CAMEL_CASE;
     }
 
 

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,13 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1
+    driverClassName: org.h2.Driver
+    username: jmtmonster
+    password:
+  h2:
+    console:
+      enabled: true
+  jpa:
+    hibernate.dialect: org.hibernate.dialect.MariaDBDialect
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate.ddl-auto: create-drop

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,7 +27,7 @@ spring:
 app:
   cors:
     # comma (',') seperated list of allowed origins for CORS
-    allowed-origins: http://localhost,http://localhost:3000
+    allowed-origins: http://localhost,http://localhost:3000,http://localhost:8001
 
 server:
   port: 8000

--- a/src/main/resources/static/docs/openapi3.json
+++ b/src/main/resources/static/docs/openapi3.json
@@ -22,11 +22,11 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/api-v1-hello1981539668"
+                  "$ref" : "#/components/schemas/api-v1-hello527089244"
                 },
                 "examples" : {
                   "hello-get" : {
-                    "value" : "{\n  \"value\" : \"hello\",\n  \"success\" : true,\n  \"createdOn\" : \"2022-04-18T03:32:46.29356\"\n}"
+                    "value" : "{\n  \"value\" : \"hello\",\n  \"success\" : true,\n  \"createdOn\" : \"2022-04-18T04:19:27.204034\"\n}"
                   }
                 }
               }
@@ -43,7 +43,7 @@
           "content" : {
             "application/json;charset=UTF-8" : {
               "schema" : {
-                "$ref" : "#/components/schemas/api-v1-hello754364377"
+                "$ref" : "#/components/schemas/api-v1-hello-1906941826"
               },
               "examples" : {
                 "hello-create" : {
@@ -59,11 +59,11 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/api-v1-hello1981539668"
+                  "$ref" : "#/components/schemas/api-v1-hello527089244"
                 },
                 "examples" : {
                   "hello-create" : {
-                    "value" : "{\n  \"value\" : \"hello example1\",\n  \"success\" : true,\n  \"createdOn\" : \"2022-04-18T03:32:46.068591\"\n}"
+                    "value" : "{\n  \"value\" : \"hello example1\",\n  \"success\" : true,\n  \"createdOn\" : \"2022-04-18T04:19:26.970268\"\n}"
                   }
                 }
               }
@@ -75,33 +75,33 @@
   },
   "components" : {
     "schemas" : {
-      "api-v1-hello1981539668" : {
+      "api-v1-hello527089244" : {
         "type" : "object",
         "properties" : {
           "success" : {
             "type" : "boolean",
-            "description" : "success flag."
+            "description" : "성공 여부를 나타내는 불린 변수"
           },
           "createdOn" : {
             "type" : "string",
-            "description" : "response created date."
+            "description" : "객체 생성 시각"
           },
           "value" : {
             "type" : "string",
-            "description" : "response message."
+            "description" : "리스폰스 메시지"
           }
         }
       },
-      "api-v1-hello754364377" : {
+      "api-v1-hello-1906941826" : {
         "type" : "object",
         "properties" : {
           "stringValue" : {
             "type" : "string",
-            "description" : "string value."
+            "description" : "문자열 값"
           },
           "intValue" : {
             "type" : "number",
-            "description" : "int value."
+            "description" : "정수 값"
           }
         }
       }

--- a/src/main/resources/static/docs/openapi3.json
+++ b/src/main/resources/static/docs/openapi3.json
@@ -26,7 +26,7 @@
                 },
                 "examples" : {
                   "hello-get" : {
-                    "value" : "{\n  \"value\" : \"hello\",\n  \"success\" : true,\n  \"createdOn\" : \"2022-04-18T03:32:08.234433\"\n}"
+                    "value" : "{\n  \"value\" : \"hello\",\n  \"success\" : true,\n  \"createdOn\" : \"2022-04-18T03:32:46.29356\"\n}"
                   }
                 }
               }
@@ -63,7 +63,7 @@
                 },
                 "examples" : {
                   "hello-create" : {
-                    "value" : "{\n  \"value\" : \"hello example1\",\n  \"success\" : true,\n  \"createdOn\" : \"2022-04-18T03:32:07.983117\"\n}"
+                    "value" : "{\n  \"value\" : \"hello example1\",\n  \"success\" : true,\n  \"createdOn\" : \"2022-04-18T03:32:46.068591\"\n}"
                   }
                 }
               }

--- a/src/main/resources/static/docs/openapi3.json
+++ b/src/main/resources/static/docs/openapi3.json
@@ -1,0 +1,110 @@
+{
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "JMT Monster",
+    "description" : "Interactive Dining Review Game",
+    "version" : "0.1.0"
+  },
+  "servers" : [ {
+    "url" : "http://localhost:8000"
+  } ],
+  "tags" : [ ],
+  "paths" : {
+    "/api/v1/hello" : {
+      "get" : {
+        "tags" : [ "api" ],
+        "summary" : "Hello 객체 조회",
+        "description" : "Hello 객체를 GET으로 가져옵니다.",
+        "operationId" : "hello-get",
+        "responses" : {
+          "200" : {
+            "description" : "200",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/api-v1-hello1981539668"
+                },
+                "examples" : {
+                  "hello-get" : {
+                    "value" : "{\n  \"value\" : \"hello\",\n  \"success\" : true,\n  \"createdOn\" : \"2022-04-18T03:32:08.234433\"\n}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "api" ],
+        "summary" : "Hello 객체 생성",
+        "description" : "Hello 객체를 POST로 만듭니다.",
+        "operationId" : "hello-create",
+        "requestBody" : {
+          "content" : {
+            "application/json;charset=UTF-8" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/api-v1-hello754364377"
+              },
+              "examples" : {
+                "hello-create" : {
+                  "value" : "{\n  \"stringValue\" : \"example\",\n  \"intValue\" : 1\n}"
+                }
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "200",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/api-v1-hello1981539668"
+                },
+                "examples" : {
+                  "hello-create" : {
+                    "value" : "{\n  \"value\" : \"hello example1\",\n  \"success\" : true,\n  \"createdOn\" : \"2022-04-18T03:32:07.983117\"\n}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "api-v1-hello1981539668" : {
+        "type" : "object",
+        "properties" : {
+          "success" : {
+            "type" : "boolean",
+            "description" : "success flag."
+          },
+          "createdOn" : {
+            "type" : "string",
+            "description" : "response created date."
+          },
+          "value" : {
+            "type" : "string",
+            "description" : "response message."
+          }
+        }
+      },
+      "api-v1-hello754364377" : {
+        "type" : "object",
+        "properties" : {
+          "stringValue" : {
+            "type" : "string",
+            "description" : "string value."
+          },
+          "intValue" : {
+            "type" : "number",
+            "description" : "int value."
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/java/com/techeer/f5/jmtmonster/domain/hello/HelloControllerTest.java
+++ b/src/test/java/com/techeer/f5/jmtmonster/domain/hello/HelloControllerTest.java
@@ -40,4 +40,18 @@ public class HelloControllerTest {
                 )));
     }
 
+    @Test
+    public void checkPostApi() throws Exception {
+
+        mockMvc.perform(post(path).accept(MediaType.APPLICATION_JSON)
+                        .param("stringValue", "example")
+                        .param("intValue", String.valueOf(1)))
+                .andExpect(status().isCreated())
+                .andDo(document("create", responseFields(
+                        fieldWithPath("value").type(JsonFieldType.STRING).description("response message."),
+                        fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("success flag."),
+                        fieldWithPath("createdOn").type(JsonFieldType.STRING).description("response created date.")
+                )));
+    }
+
 }

--- a/src/test/java/com/techeer/f5/jmtmonster/domain/hello/HelloControllerTest.java
+++ b/src/test/java/com/techeer/f5/jmtmonster/domain/hello/HelloControllerTest.java
@@ -1,57 +1,99 @@
 package com.techeer.f5.jmtmonster.domain.hello;
 
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
+
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.techeer.f5.jmtmonster.domain.hello.controller.HelloController;
+import com.techeer.f5.jmtmonster.domain.hello.dto.HelloRequestDto;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(HelloController.class)
-@AutoConfigureRestDocs(outputDir = "target/hello")
+@AutoConfigureRestDocs
 // For use test db
 @TestPropertySource("classpath:application-test.yml")
 public class HelloControllerTest {
     // See https://spring.io/guides/gs/testing-restdocs/
     @Autowired
     private MockMvc mockMvc;
-    private String path = "/api/v1/hello";
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @Test
     public void checkGetApi() throws Exception {
-
-        mockMvc.perform(get(path).accept(MediaType.APPLICATION_JSON))
+        mockMvc.perform(RestDocumentationRequestBuilders.get("/api/v1/hello")
+                            .accept(MediaType.APPLICATION_JSON)
+                            .with(csrf()))
                     .andDo(print())
                     .andExpect(status().isOk())
-                .andDo(document("get", responseFields(
-                        fieldWithPath("value").type(JsonFieldType.STRING).description("response message."),
-                        fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("success flag."),
-                        fieldWithPath("createdOn").type(JsonFieldType.STRING).description("response created date.")
-                )));
+                    .andDo(MockMvcRestDocumentationWrapper.document("hello-get",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            resource(
+                                    ResourceSnippetParameters.builder()
+                                            .description("Hello 객체를 GET으로 가져옵니다.")
+                                            .summary("Hello 객체 조회")
+                                            .responseFields(
+                                                    fieldWithPath("value").type(JsonFieldType.STRING).description("response message."),
+                                                    fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("success flag."),
+                                                    fieldWithPath("createdOn").type(JsonFieldType.STRING).description("response created date.")
+                                            )
+                                            .build()
+                            )
+                    ));
     }
 
     @Test
     public void checkPostApi() throws Exception {
+        HelloRequestDto requestDto = HelloRequestDto.builder()
+                                        .stringValue("example")
+                                        .intValue(1L)
+                                        .build();
+        String requestBody = objectMapper.writeValueAsString(requestDto);
 
-        mockMvc.perform(post(path).accept(MediaType.APPLICATION_JSON)
-                        .param("stringValue", "example")
-                        .param("intValue", String.valueOf(1)))
-                .andExpect(status().isCreated())
-                .andDo(document("create", responseFields(
-                        fieldWithPath("value").type(JsonFieldType.STRING).description("response message."),
-                        fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("success flag."),
-                        fieldWithPath("createdOn").type(JsonFieldType.STRING).description("response created date.")
-                )));
+        mockMvc.perform(RestDocumentationRequestBuilders.post("/api/v1/hello")
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestBody)
+                            .with(csrf()))
+                .andDo(print())
+                .andExpect(status().is(200))
+                .andDo(document("hello-create",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .description("Hello 객체를 POST로 만듭니다.")
+                                        .summary("Hello 객체 생성")
+                                        .requestFields(
+                                                fieldWithPath("stringValue").type(JsonFieldType.STRING).description("string value."),
+                                                fieldWithPath("intValue").type(JsonFieldType.NUMBER).description("int value.")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("value").type(JsonFieldType.STRING).description("response message."),
+                                                fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("success flag."),
+                                                fieldWithPath("createdOn").type(JsonFieldType.STRING).description("response created date.")
+                                        )
+                                        .build()
+                        )
+                ));
     }
 
 }

--- a/src/test/java/com/techeer/f5/jmtmonster/domain/hello/HelloControllerTest.java
+++ b/src/test/java/com/techeer/f5/jmtmonster/domain/hello/HelloControllerTest.java
@@ -51,9 +51,9 @@ public class HelloControllerTest {
                                             .description("Hello 객체를 GET으로 가져옵니다.")
                                             .summary("Hello 객체 조회")
                                             .responseFields(
-                                                    fieldWithPath("value").type(JsonFieldType.STRING).description("response message."),
-                                                    fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("success flag."),
-                                                    fieldWithPath("createdOn").type(JsonFieldType.STRING).description("response created date.")
+                                                    fieldWithPath("value").type(JsonFieldType.STRING).description("리스폰스 메시지"),
+                                                    fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부를 나타내는 불린 변수"),
+                                                    fieldWithPath("createdOn").type(JsonFieldType.STRING).description("객체 생성 시각")
                                             )
                                             .build()
                             )
@@ -83,13 +83,13 @@ public class HelloControllerTest {
                                         .description("Hello 객체를 POST로 만듭니다.")
                                         .summary("Hello 객체 생성")
                                         .requestFields(
-                                                fieldWithPath("stringValue").type(JsonFieldType.STRING).description("string value."),
-                                                fieldWithPath("intValue").type(JsonFieldType.NUMBER).description("int value.")
+                                                fieldWithPath("stringValue").type(JsonFieldType.STRING).description("문자열 값"),
+                                                fieldWithPath("intValue").type(JsonFieldType.NUMBER).description("정수 값")
                                         )
                                         .responseFields(
-                                                fieldWithPath("value").type(JsonFieldType.STRING).description("response message."),
-                                                fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("success flag."),
-                                                fieldWithPath("createdOn").type(JsonFieldType.STRING).description("response created date.")
+                                                fieldWithPath("value").type(JsonFieldType.STRING).description("리스폰스 메시지"),
+                                                fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부를 나타내는 불린 변수"),
+                                                fieldWithPath("createdOn").type(JsonFieldType.STRING).description("객체 생성 시각")
                                         )
                                         .build()
                         )

--- a/src/test/java/com/techeer/f5/jmtmonster/domain/hello/HelloControllerTest.java
+++ b/src/test/java/com/techeer/f5/jmtmonster/domain/hello/HelloControllerTest.java
@@ -1,0 +1,43 @@
+package com.techeer.f5.jmtmonster.domain.hello;
+
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+import com.techeer.f5.jmtmonster.domain.hello.controller.HelloController;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(HelloController.class)
+@AutoConfigureRestDocs(outputDir = "target/hello")
+// For use test db
+@TestPropertySource("classpath:application-test.yml")
+public class HelloControllerTest {
+    // See https://spring.io/guides/gs/testing-restdocs/
+    @Autowired
+    private MockMvc mockMvc;
+    private String path = "/api/v1/hello";
+
+    @Test
+    public void checkGetApi() throws Exception {
+
+        mockMvc.perform(get(path).accept(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                .andDo(document("get", responseFields(
+                        fieldWithPath("value").type(JsonFieldType.STRING).description("response message."),
+                        fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("success flag."),
+                        fieldWithPath("createdOn").type(JsonFieldType.STRING).description("response created date.")
+                )));
+    }
+
+}

--- a/src/test/java/com/techeer/f5/jmtmonster/global/ApplicationTests.java
+++ b/src/test/java/com/techeer/f5/jmtmonster/global/ApplicationTests.java
@@ -1,4 +1,4 @@
-package com.techeer.f5.jmtmonster;
+package com.techeer.f5.jmtmonster.global;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
## DONE
* Jackson LocalDateTime 파서 연동
* Jackson PropertyNamingStrategy LowerCamelCase로 설정
* Jackson TimeStamp 형식으로 반환하지 않도록 함. TZ로 변경
* HelloControllerTest MockMvc & Spring REST Docs로 테스트 작성
* 테스트용 H2 DB 초기화 및 yml 적용
* [rest-api-spec](https://github.com/ePages-de/restdocs-api-spec) 사용해서 RestDocs spec -> OpenAPI 3 spec으로 변환
* Docker Compose 사용해서 swagger-ui 컨테이너 8001 포트에 생성
* 8001 포트 CORS 해제