### PR TITLE
Github Actions 이미지 빌드 & AWS ECR 연동

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,4 +1,4 @@
-name: CD
+name: Build Image
 on:
   push:
     branches:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -42,8 +42,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_ECR_SECRET_ACCESS_KEY }}
           aws-region: ap-northeast-2
       - name: Login to Amazon ECR
-        run: |
-          docker login -u AWS -p $(aws ecr-public get-login-password --region ap-northeast-2) public.ecr.aws/w1d0u6d8
+        uses: aws-actions/amazon-ecr-login@v1
       - name: Build and push images & upload to ECR
         id: build_images
         run: |

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   duplicate_guard:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
@@ -22,7 +22,7 @@ jobs:
   docker-build:
     needs: duplicate_guard
     if: ${{ needs.duplicate_guard.outputs.should_skip != 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -46,7 +46,8 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_ECR_SECRET_ACCESS_KEY }}
           aws-region: ap-northeast-2
       - name: Login to Amazon ECR
-        uses: aws-actions/amazon-ecr-login@v1
+        run: |
+          docker login -u AWS -p $(aws ecr-public get-login-password --region ap-northeast-2) public.ecr.aws/w1d0u6d8
       - name: Build and push images & upload to ECR
         id: build_images
         run: |

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -44,10 +44,10 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ECR_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_ECR_SECRET_ACCESS_KEY }}
-          aws-region: ap-northeast-2
+          aws-region: us-east-1
       - name: Login to Amazon ECR
         run: |
-          docker login -u AWS -p $(aws ecr-public get-login-password --region ap-northeast-2) public.ecr.aws/w1d0u6d8
+          docker login -u AWS -p $(aws ecr-public get-login-password --region us-east-1) public.ecr.aws/w1d0u6d8
       - name: Build and push images & upload to ECR
         id: build_images
         run: |

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,52 @@
+name: CD
+on:
+  push:
+    branches:
+      - main
+      - feat/github-actions-build-image
+
+jobs:
+  duplicate_guard:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: "never"
+          skip_after_successful_duplicate: "true"
+          paths_ignore: '["**/README.md", "**/docs/**"]'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+
+  docker-build:
+    needs: duplicate_guard
+    if: ${{ needs.duplicate_guard.outputs.should_skip != 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Set up AWS Cli
+        run: |
+          sudo apt update -y
+          sudo apt install awscli -y
+          aws --version
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ECR_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_ECR_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
+      - name: Login to Amazon ECR
+        run: |
+          docker login -u AWS -p $(aws ecr-public get-login-password --region ap-northeast-2) public.ecr.aws/w1d0u6d8
+      - name: Build and push images & upload to ECR
+        id: build_images
+        run: |
+          ./gradlew bootBuildImage
+          docker tag jmt-monster-backend:latest public.ecr.aws/w1d0u6d8/jmt-monster-backend:latest
+          docker push public.ecr.aws/w1d0u6d8/jmt-monster-backend:latest

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -30,6 +30,10 @@ jobs:
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+      - name: Set up Java for Gradle
+        run: |
+          sudo apt update -y
+          sudo apt install openjdk-17-jdk -y
       - name: Set up AWS Cli
         run: |
           sudo apt update -y

--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,6 @@ application-secret.yml
 
 target
 
+### ACT Secret file ###
+### See https://github.com/nektos/act ###
 .secret

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ out/
 application-secret.yml
 
 target
+
+.secret

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,10 @@ tasks.named('asciidoctor') {
     dependsOn test
 }
 
+tasks.named("bootBuildImage") {
+    imageName = "jmt-monster-backend:latest"
+}
+
 // ./gradlew openapi3
 // See /src/main/resources/static/docs/openapi3.json
 openapi3 {


### PR DESCRIPTION
## DONE
* AWS ECR Public Registry 생성, Github Secrets에 추가
* Gradle bootBuildImage등을 사용한 Github Action 정의 작성
* main / feat/github-actions-build-image branch가 push될 때마다 이미지 빌드 후 AWS ECR에 push

## TODO
[Notion 페이지](https://www.notion.so/litsynp/1-d3caa7585aaa4c09848cfce80c303d45#b2d43bff684c4f27aad8201c4294f32d) 참고