### PR TITLE
친구 API

### DIFF
--- a/src/main/java/com/techeer/f5/jmtmonster/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/friend/controller/FriendController.java
@@ -1,0 +1,61 @@
+package com.techeer.f5.jmtmonster.domain.friend.controller;
+
+import com.techeer.f5.jmtmonster.domain.friend.dto.mapper.FriendMapper;
+import com.techeer.f5.jmtmonster.domain.friend.dto.request.FriendUpdateRequestDto;
+import com.techeer.f5.jmtmonster.domain.friend.dto.response.FriendResponseDto;
+import com.techeer.f5.jmtmonster.domain.friend.service.FriendService;
+import java.util.UUID;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/friends")
+@RequiredArgsConstructor
+public class FriendController {
+
+    private final FriendService service;
+    private final FriendMapper mapper;
+
+    @GetMapping("/{id}")
+    public ResponseEntity<FriendResponseDto> getOne(@PathVariable UUID id) {
+        return ResponseEntity
+                .ok(mapper.toResponseDto(service.findFriendById(id)));
+    }
+
+    @GetMapping
+    public ResponseEntity<Page<FriendResponseDto>> getList(
+            @PageableDefault(size = 20, sort = "createdOn", direction = Direction.DESC) final Pageable pageable
+    ) {
+        return ResponseEntity
+                .ok(service.findAllFriends(pageable).map(mapper::toResponseDto));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<FriendResponseDto> update(
+            @PathVariable UUID id,
+            @Valid @RequestBody FriendUpdateRequestDto dto
+    ) {
+        return ResponseEntity
+                .ok(mapper.toResponseDto(service.updateFriend(id, mapper.toServiceDto(dto))));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable UUID id) {
+        service.deleteFriendById(id);
+        return ResponseEntity
+                .noContent()
+                .build();
+    }
+}

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/friend/controller/FriendRequestController.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/friend/controller/FriendRequestController.java
@@ -8,7 +8,7 @@ import com.techeer.f5.jmtmonster.domain.friend.dto.request.FriendRequestCreateRe
 import com.techeer.f5.jmtmonster.domain.friend.dto.request.FriendRequestModel;
 import com.techeer.f5.jmtmonster.domain.friend.dto.request.FriendRequestUpdateRequestDto;
 import com.techeer.f5.jmtmonster.domain.friend.dto.response.FriendRequestResponseDto;
-import com.techeer.f5.jmtmonster.domain.friend.service.FriendRequestService;
+import com.techeer.f5.jmtmonster.domain.friend.service.FriendService;
 import java.util.UUID;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -32,7 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class FriendRequestController {
 
-    private final FriendRequestService service;
+    private final FriendService service;
     private final FriendRequestMapper mapper;
 
     // TODO: add authorization with given user identity
@@ -42,7 +42,7 @@ public class FriendRequestController {
     public ResponseEntity<FriendRequestModel> create(
             @Valid @RequestBody FriendRequestCreateRequestDto dto
     ) {
-        FriendRequest entity = service.create(mapper.toServiceDto(dto));
+        FriendRequest entity = service.createRequest(mapper.toServiceDto(dto));
         FriendRequestResponseDto response = mapper.toResponseDto(entity);
 
         WebMvcLinkBuilder listLink = linkTo(FriendRequestController.class);
@@ -63,7 +63,7 @@ public class FriendRequestController {
     public ResponseEntity<FriendRequestResponseDto> getOne(@PathVariable UUID id) {
 
         return ResponseEntity
-                .ok(mapper.toResponseDto(service.findOneById(id)));
+                .ok(mapper.toResponseDto(service.findRequestById(id)));
     }
 
     @GetMapping
@@ -71,7 +71,7 @@ public class FriendRequestController {
             @PageableDefault(size = 20, sort = "createdOn", direction = Direction.DESC) final Pageable pageable
     ) {
         return ResponseEntity
-                .ok(service.findAll(pageable).map(mapper::toResponseDto));
+                .ok(service.findAllRequests(pageable).map(mapper::toResponseDto));
     }
 
     @PutMapping("/{id}")
@@ -80,12 +80,12 @@ public class FriendRequestController {
             @Valid @RequestBody FriendRequestUpdateRequestDto dto
     ) {
         return ResponseEntity
-                .ok(mapper.toResponseDto(service.update(id, mapper.toServiceDto(dto))));
+                .ok(mapper.toResponseDto(service.updateRequest(id, mapper.toServiceDto(dto))));
     }
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> delete(@PathVariable UUID id) {
-        service.deleteById(id);
+        service.deleteRequestById(id);
         return ResponseEntity
                 .noContent()
                 .build();

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/friend/dao/FriendRepository.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/friend/dao/FriendRepository.java
@@ -1,0 +1,8 @@
+package com.techeer.f5.jmtmonster.domain.friend.dao;
+
+import com.techeer.f5.jmtmonster.domain.friend.domain.Friend;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FriendRepository extends JpaRepository<Friend, UUID> {
+}

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/friend/domain/Friend.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/friend/domain/Friend.java
@@ -1,0 +1,51 @@
+package com.techeer.f5.jmtmonster.domain.friend.domain;
+
+import com.techeer.f5.jmtmonster.domain.user.domain.User;
+import com.techeer.f5.jmtmonster.global.domain.domain.BaseTimeEntity;
+import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.hibernate.annotations.GenericGenerator;
+
+@Entity
+@Getter
+@ToString
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Friend extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Column(columnDefinition = "BINARY(16)")
+    @Builder.Default
+    private UUID id = UUID.randomUUID();
+
+    @ManyToOne
+    @NotNull
+    private User fromUser;
+
+    @ManyToOne
+    @NotNull
+    private User toUser;
+
+    @NotNull
+    private boolean isHangingOut;
+
+    public void update(User fromUser, User toUser, boolean isHangingOut) {
+        this.fromUser = fromUser;
+        this.toUser = toUser;
+        this.isHangingOut = isHangingOut;
+    }
+}

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/friend/dto/mapper/FriendMapper.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/friend/dto/mapper/FriendMapper.java
@@ -1,0 +1,31 @@
+package com.techeer.f5.jmtmonster.domain.friend.dto.mapper;
+
+import com.techeer.f5.jmtmonster.domain.friend.domain.Friend;
+import com.techeer.f5.jmtmonster.domain.friend.dto.request.FriendUpdateRequestDto;
+import com.techeer.f5.jmtmonster.domain.friend.dto.request.FriendUpdateServiceDto;
+import com.techeer.f5.jmtmonster.domain.friend.dto.response.FriendResponseDto;
+import com.techeer.f5.jmtmonster.domain.user.dto.UserMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class FriendMapper {
+
+    private final UserMapper userMapper;
+
+    public FriendResponseDto toResponseDto(Friend entity) {
+        return FriendResponseDto.builder()
+                .id(entity.getId())
+                .fromUser(userMapper.toBasicUserResponseDto(entity.getFromUser()))
+                .toUser(userMapper.toBasicUserResponseDto(entity.getToUser()))
+                .isHangingOut(entity.isHangingOut())
+                .build();
+    }
+
+    public FriendUpdateServiceDto toServiceDto(FriendUpdateRequestDto dto) {
+        return FriendUpdateServiceDto.builder()
+                .isHangingOut(dto.isHangingOut())
+                .build();
+    }
+}

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/friend/dto/request/FriendRequestUpdateRequestDto.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/friend/dto/request/FriendRequestUpdateRequestDto.java
@@ -1,7 +1,6 @@
 package com.techeer.f5.jmtmonster.domain.friend.dto.request;
 
 import com.techeer.f5.jmtmonster.domain.friend.domain.FriendRequestStatus;
-import java.util.UUID;
 import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -14,12 +13,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FriendRequestUpdateRequestDto {
-
-    @NotNull
-    private UUID fromUserId;
-
-    @NotNull
-    private UUID toUserId;
 
     @NotNull
     private FriendRequestStatus status;

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/friend/dto/request/FriendUpdateRequestDto.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/friend/dto/request/FriendUpdateRequestDto.java
@@ -1,0 +1,18 @@
+package com.techeer.f5.jmtmonster.domain.friend.dto.request;
+
+import javax.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FriendUpdateRequestDto {
+
+    @NotNull
+    private boolean isHangingOut;
+}

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/friend/dto/request/FriendUpdateServiceDto.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/friend/dto/request/FriendUpdateServiceDto.java
@@ -1,0 +1,18 @@
+package com.techeer.f5.jmtmonster.domain.friend.dto.request;
+
+import javax.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FriendUpdateServiceDto {
+
+    @NotNull
+    private boolean isHangingOut;
+}

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/friend/dto/response/FriendResponseDto.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/friend/dto/response/FriendResponseDto.java
@@ -1,0 +1,30 @@
+package com.techeer.f5.jmtmonster.domain.friend.dto.response;
+
+import com.techeer.f5.jmtmonster.domain.user.dto.BasicUserResponseDto;
+import com.techeer.f5.jmtmonster.global.domain.dto.BaseTimeEntityDto;
+import java.util.UUID;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class FriendResponseDto extends BaseTimeEntityDto {
+
+    @NotNull
+    private UUID id;
+
+    @NotNull
+    private BasicUserResponseDto fromUser;
+
+    @NotNull
+    private BasicUserResponseDto toUser;
+
+    @NotNull
+    private boolean isAccepted;
+
+    @NotNull
+    private boolean isHangingOut;
+}

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/friend/service/FriendService.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/friend/service/FriendService.java
@@ -1,10 +1,13 @@
 package com.techeer.f5.jmtmonster.domain.friend.service;
 
+import com.techeer.f5.jmtmonster.domain.friend.dao.FriendRepository;
 import com.techeer.f5.jmtmonster.domain.friend.dao.FriendRequestRepository;
+import com.techeer.f5.jmtmonster.domain.friend.domain.Friend;
 import com.techeer.f5.jmtmonster.domain.friend.domain.FriendRequest;
 import com.techeer.f5.jmtmonster.domain.friend.domain.FriendRequestStatus;
 import com.techeer.f5.jmtmonster.domain.friend.dto.request.FriendRequestCreateServiceDto;
 import com.techeer.f5.jmtmonster.domain.friend.dto.request.FriendRequestUpdateServiceDto;
+import com.techeer.f5.jmtmonster.domain.friend.dto.request.FriendUpdateServiceDto;
 import com.techeer.f5.jmtmonster.domain.user.domain.User;
 import com.techeer.f5.jmtmonster.domain.user.repository.UserRepository;
 import com.techeer.f5.jmtmonster.global.error.exception.DuplicateResourceException;
@@ -23,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class FriendService {
 
+    private final FriendRepository friendRepository;
     private final FriendRequestRepository friendRequestRepository;
     private final UserRepository userRepository;
 
@@ -108,3 +112,35 @@ public class FriendService {
     public Page<FriendRequest> findAllRequests(Pageable pageable) {
         return friendRequestRepository.findAll(pageable);
     }
+
+    @Transactional
+    public Friend updateFriend(UUID id, FriendUpdateServiceDto dto) {
+
+        Friend entity = friendRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException(Friend.class.getSimpleName(), "id",
+                        id));
+
+        entity.update(entity.getFromUser(), entity.getToUser(), dto.isHangingOut());
+        return friendRepository.save(entity);
+    }
+
+    @Transactional
+    public void deleteFriendById(UUID id) {
+        if (!friendRepository.existsById(id)) {
+            throw new ResourceNotFoundException(Friend.class.getSimpleName(), "id", id);
+        }
+        friendRepository.deleteById(id);
+    }
+
+    @Transactional(readOnly = true)
+    public Friend findFriendById(UUID id) {
+        return friendRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        Friend.class.getSimpleName(), "id", id));
+    }
+
+    @Transactional(readOnly = true)
+    public Page<Friend> findAllFriends(Pageable pageable) {
+        return friendRepository.findAll(pageable);
+    }
+}


### PR DESCRIPTION
## DONE
- 친구 API 구현
- 친구 Service와 친구 요청 Service 통합 관리
  - 현재는 친구 요청을 PUT 요청을 통해 `isAccepted` 값을 `ACCEPTED`로 수정하여 "수락"하는 동시에 Friend 테이블에 row가 추가되는 방식
  - 따라서 Service 기능이 중첩된다고 판단하여 통합

## TODO
- Authorization
- `@RequestParam`을 이용한 친구 요청 및 친구 API의 필터링 (fromUserId, toUserId, createdOn, ...)

## BUGS
- 개발 과정에서 #36 발견

## SCREENSHOTS

### 친구 요청 생성
![image](https://user-images.githubusercontent.com/42485462/166636346-2459fdff-d2d1-4a08-a66a-3655b47a69d7.png)

### 친구 요청 수락
![image](https://user-images.githubusercontent.com/42485462/166636361-45792818-fb29-4603-8421-74730ccc0a7f.png)

### 친구 조회
![image](https://user-images.githubusercontent.com/42485462/166636368-fc271fea-6e53-4cf7-acd8-afa14a92ecda.png)
