### PR TITLE
음식점 도메인 추가

### DIFF
--- a/src/main/java/com/techeer/f5/jmtmonster/domain/restaurant/controller/RestaurantController.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/restaurant/controller/RestaurantController.java
@@ -1,0 +1,35 @@
+package com.techeer.f5.jmtmonster.domain.restaurant.controller;
+
+import com.techeer.f5.jmtmonster.domain.restaurant.dto.mapper.RestaurantMapper;
+import com.techeer.f5.jmtmonster.domain.restaurant.dto.response.RestaurantResponseDto;
+import com.techeer.f5.jmtmonster.domain.restaurant.entity.Restaurant;
+import com.techeer.f5.jmtmonster.domain.restaurant.repository.RestaurantRepository;
+import com.techeer.f5.jmtmonster.domain.restaurant.service.RestaurantService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/v1/restaurants")
+@RequiredArgsConstructor
+public class RestaurantController {
+
+    private final RestaurantService restaurantService;
+    private final RestaurantRepository restaurantRepository;
+
+    @PostMapping("/{cid}")
+    public ResponseEntity getRestaurantInformation(@PathVariable Long cid) {
+        RestaurantResponseDto responseDto;
+        if (restaurantRepository.existsByCid(cid)) {  // 정보가 있으면
+            responseDto = restaurantService.getRestaurantInfo(cid);
+        } else { // 정보가 없으면
+            responseDto = restaurantService.saveRestaurantInfo(cid);
+        }
+
+        return ResponseEntity.ok()
+                .body(responseDto);
+    }
+}

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/restaurant/dto/mapper/RestaurantMapper.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/restaurant/dto/mapper/RestaurantMapper.java
@@ -1,0 +1,30 @@
+package com.techeer.f5.jmtmonster.domain.restaurant.dto.mapper;
+
+import com.nimbusds.jose.shaded.json.JSONObject;
+import com.techeer.f5.jmtmonster.domain.restaurant.dto.response.RestaurantResponseDto;
+import com.techeer.f5.jmtmonster.domain.restaurant.entity.Restaurant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RestaurantMapper {
+    public Restaurant toEntity(JSONObject jsonObject, Long cid) {
+        return Restaurant.builder()
+                .cid(cid)
+                .name(jsonObject.getAsString("name"))
+                .x_cord(Long.parseLong(jsonObject.getAsString("x_cord")))
+                .y_cord(Long.parseLong(jsonObject.getAsString("y_cord")))
+                .build();
+    }
+
+    public RestaurantResponseDto toResponseDto(Restaurant restaurant) {
+        return RestaurantResponseDto.builder()
+                .id(restaurant.getId())
+                .cid(restaurant.getCid())
+                .name(restaurant.getName())
+                .x_cord(restaurant.getX_cord())
+                .y_cord(restaurant.getY_cord())
+                .build();
+    }
+}

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/restaurant/dto/request/RestaurantRequestDto.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/restaurant/dto/request/RestaurantRequestDto.java
@@ -1,0 +1,4 @@
+package com.techeer.f5.jmtmonster.domain.restaurant.dto.request;
+
+public class RestaurantRequestDto {
+}

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/restaurant/dto/response/RestaurantResponseDto.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/restaurant/dto/response/RestaurantResponseDto.java
@@ -1,0 +1,18 @@
+package com.techeer.f5.jmtmonster.domain.restaurant.dto.response;
+
+import lombok.*;
+
+import java.util.UUID;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RestaurantResponseDto {
+
+    private UUID id;
+    private Long cid;
+    private String name;
+    private Long x_cord;
+    private Long y_cord;
+}

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/restaurant/entity/Restaurant.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/restaurant/entity/Restaurant.java
@@ -1,0 +1,40 @@
+package com.techeer.f5.jmtmonster.domain.restaurant.entity;
+
+import com.sun.istack.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.util.UUID;
+
+@Getter
+@Table(name = "Restaurant")
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Restaurant {
+    // Todo 휴대폰 번호, 주소 등 추가 정보 저장이 필요할 시 Column 추가
+    // Todo 특히 주소에 대한 엔티티 고민해봐야 함
+
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Builder.Default
+    private UUID id = UUID.randomUUID();
+
+    @NotNull
+    private Long cid;
+
+    private String name;
+
+    private Long x_cord;
+    private Long y_cord;
+
+}

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/restaurant/repository/RestaurantRepository.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/restaurant/repository/RestaurantRepository.java
@@ -1,0 +1,15 @@
+package com.techeer.f5.jmtmonster.domain.restaurant.repository;
+
+import com.techeer.f5.jmtmonster.domain.restaurant.entity.Restaurant;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface RestaurantRepository extends JpaRepository<Restaurant, UUID> {
+    Optional<Restaurant> findByCid(Long cid);
+    boolean existsByCid(Long cid);
+
+}

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/restaurant/service/RestaurantService.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/restaurant/service/RestaurantService.java
@@ -1,0 +1,42 @@
+package com.techeer.f5.jmtmonster.domain.restaurant.service;
+
+import com.nimbusds.jose.shaded.json.JSONObject;
+import com.techeer.f5.jmtmonster.domain.restaurant.dto.mapper.RestaurantMapper;
+import com.techeer.f5.jmtmonster.domain.restaurant.dto.response.RestaurantResponseDto;
+import com.techeer.f5.jmtmonster.domain.restaurant.entity.Restaurant;
+import com.techeer.f5.jmtmonster.domain.restaurant.repository.RestaurantRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+//import javax.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+public class RestaurantService {
+
+    private final RestaurantRepository restaurantRepository;
+    private final RestaurantMapper restaurantMapper;
+
+    @Transactional(readOnly = true)
+    public RestaurantResponseDto getRestaurantInfo(Long cid) {
+        return restaurantMapper.toResponseDto(restaurantRepository.findByCid(cid).get());
+    }
+
+    @Transactional
+    public RestaurantResponseDto saveRestaurantInfo(Long cid) {
+        JSONObject jsonObject = new JSONObject();
+        // Todo: 외부 요청을 통한 결과를 JsonObject로 반환
+        // 임시 값 저장
+        jsonObject.put("cid", "562795624");
+        jsonObject.put("name", "롯데리아 인천공항제2여객터미널3층점");
+        jsonObject.put("x_cord", "374960");
+        jsonObject.put("y_cord", "1102598");
+
+        Restaurant restaurant = restaurantMapper.toEntity(jsonObject, cid);
+
+        return restaurantMapper.toResponseDto(restaurantRepository.save(restaurant));
+    }
+
+}


### PR DESCRIPTION
# 음식점 도메인 추가  

## 작업 내용
- Restaurants 도메인 추가
- Controller, Service, Repository, Dtos, Entity 추가
- cid를 파라미터로 Restaurant 정보를 요청받음
    - 데이터베이스에 cid를 조회하여 엔티티가 존재하면 해당 엔티티를 반환
    - 데이터베이스에 cid를 조회하여 엔티티가 존재하지 않으면 `[GET]` `https://place.map.kakao.com/main/v/{cid}`를 통하여 정보를 받아 새로운 엔티티 추가

## Todo
- 외부 API 요청을 통한 음식점 정보 수집

## 요청 사항
- 외부 API 요청에 대한 로직을 `Service layer`에서 작업해주시기 바랍니다