### PR TITLE
친구 요청 API 쿼리 성능 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,17 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'
+
+    // Querydsl
+    implementation 'com.querydsl:querydsl-jpa'
+
+    // Querydsl JPAAnnotationProcessor 사용 지정
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa"
+    // java.lang.NoClassDefFoundError(javax.annotation.Entity) 발생 대응
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    // java.lang.NoClassDefFoundError(javax.annotation.Generated) 발생 대응
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     implementation 'org.springframework.boot:spring-boot-starter-test'
@@ -61,6 +72,12 @@ tasks.named('asciidoctor') {
 
 tasks.named("bootBuildImage") {
     imageName = "jmt-monster-backend:latest"
+}
+
+// clean task 실행시 QClass 삭제
+tasks.clean {
+    // IntelliJ Annotation processor 생성물 생성 위치
+    delete file('src/main/generated')
 }
 
 // ./gradlew openapi3

--- a/build.gradle
+++ b/build.gradle
@@ -31,12 +31,13 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.0.1.RELEASE'
     implementation 'org.flywaydb:flyway-core'
     implementation 'com.fasterxml.jackson.core:jackson-core:2.13.2'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.2'
+
     compileOnly 'org.projectlombok:lombok'
-    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.0.1.RELEASE'
-    developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'
 
@@ -52,6 +53,7 @@ dependencies {
 
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+
     implementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation 'org.springframework.security:spring-security-test'
@@ -83,7 +85,7 @@ tasks.clean {
 // ./gradlew openapi3
 // See /src/main/resources/static/docs/openapi3.json
 openapi3 {
-    servers = [ { url = 'http://localhost:8000' }, { url = 'https://backend.jmtmonster.com' } ]
+    servers = [{ url = 'http://localhost:8000' }, { url = 'https://backend.jmtmonster.com' }]
     title = 'JMT Monster'
     description = 'Interactive Dining Review Game'
     version = '0.1.0'

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/friend/dao/FriendRequestCustomRepository.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/friend/dao/FriendRequestCustomRepository.java
@@ -1,0 +1,11 @@
+package com.techeer.f5.jmtmonster.domain.friend.dao;
+
+import com.techeer.f5.jmtmonster.domain.friend.domain.FriendRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+public interface FriendRequestCustomRepository {
+
+    Page<FriendRequest> findAll(Pageable pageable);
+}

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/friend/dao/FriendRequestCustomRepository.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/friend/dao/FriendRequestCustomRepository.java
@@ -2,7 +2,6 @@ package com.techeer.f5.jmtmonster.domain.friend.dao;
 
 import com.techeer.f5.jmtmonster.domain.friend.domain.FriendRequest;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
 public interface FriendRequestCustomRepository {

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/friend/dao/FriendRequestCustomRepositoryImpl.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/friend/dao/FriendRequestCustomRepositoryImpl.java
@@ -1,0 +1,42 @@
+package com.techeer.f5.jmtmonster.domain.friend.dao;
+
+import static com.techeer.f5.jmtmonster.domain.friend.domain.QFriendRequest.friendRequest;
+import static com.techeer.f5.jmtmonster.domain.user.domain.QUser.user;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.techeer.f5.jmtmonster.domain.friend.domain.FriendRequest;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class FriendRequestCustomRepositoryImpl implements FriendRequestCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<FriendRequest> findAll(Pageable pageable) {
+        List<FriendRequest> query = jpaQueryFactory
+                .selectFrom(friendRequest)
+                .innerJoin(friendRequest.fromUser, user)
+                .fetchJoin()
+                .innerJoin(friendRequest.toUser, user)
+                .fetchJoin()
+                .fetch();
+
+        JPAQuery<Long> countQuery = getCount();
+
+        return PageableExecutionUtils.getPage(query, pageable, countQuery::fetchOne);
+    }
+
+    private JPAQuery<Long> getCount() {
+        return jpaQueryFactory
+                .select(friendRequest.count())
+                .from(friendRequest);
+    }
+}

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/friend/dao/FriendRequestRepository.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/friend/dao/FriendRequestRepository.java
@@ -4,7 +4,7 @@ import com.techeer.f5.jmtmonster.domain.friend.domain.FriendRequest;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface FriendRequestRepository extends JpaRepository<FriendRequest, UUID> {
+public interface FriendRequestRepository extends JpaRepository<FriendRequest, UUID>, FriendRequestCustomRepository {
 
     boolean existsByFromUser_idAndToUser_id(UUID fromUserId, UUID toUserId);
 }

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/friend/service/FriendService.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/friend/service/FriendService.java
@@ -1,6 +1,7 @@
 package com.techeer.f5.jmtmonster.domain.friend.service;
 
 import com.techeer.f5.jmtmonster.domain.friend.dao.FriendRepository;
+import com.techeer.f5.jmtmonster.domain.friend.dao.FriendRequestCustomRepository;
 import com.techeer.f5.jmtmonster.domain.friend.dao.FriendRequestRepository;
 import com.techeer.f5.jmtmonster.domain.friend.domain.Friend;
 import com.techeer.f5.jmtmonster.domain.friend.domain.FriendRequest;
@@ -28,6 +29,7 @@ public class FriendService {
 
     private final FriendRepository friendRepository;
     private final FriendRequestRepository friendRequestRepository;
+    private final FriendRequestCustomRepository friendRequestCustomRepository;
     private final UserRepository userRepository;
 
     @Transactional
@@ -110,7 +112,7 @@ public class FriendService {
 
     @Transactional(readOnly = true)
     public Page<FriendRequest> findAllRequests(Pageable pageable) {
-        return friendRequestRepository.findAll(pageable);
+        return friendRequestCustomRepository.findAll(pageable);
     }
 
     @Transactional

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/friend/service/FriendService.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/friend/service/FriendService.java
@@ -1,7 +1,6 @@
 package com.techeer.f5.jmtmonster.domain.friend.service;
 
 import com.techeer.f5.jmtmonster.domain.friend.dao.FriendRepository;
-import com.techeer.f5.jmtmonster.domain.friend.dao.FriendRequestCustomRepository;
 import com.techeer.f5.jmtmonster.domain.friend.dao.FriendRequestRepository;
 import com.techeer.f5.jmtmonster.domain.friend.domain.Friend;
 import com.techeer.f5.jmtmonster.domain.friend.domain.FriendRequest;
@@ -29,7 +28,6 @@ public class FriendService {
 
     private final FriendRepository friendRepository;
     private final FriendRequestRepository friendRequestRepository;
-    private final FriendRequestCustomRepository friendRequestCustomRepository;
     private final UserRepository userRepository;
 
     @Transactional
@@ -112,7 +110,7 @@ public class FriendService {
 
     @Transactional(readOnly = true)
     public Page<FriendRequest> findAllRequests(Pageable pageable) {
-        return friendRequestCustomRepository.findAll(pageable);
+        return friendRequestRepository.findAll(pageable);
     }
 
     @Transactional

--- a/src/main/java/com/techeer/f5/jmtmonster/global/config/QuerydslConfig.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/global/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.techeer.f5.jmtmonster.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,7 @@ spring:
         # Print extra information besides SQL queries for debugging
         use_sql_comments: true
         ddl-auto: update
+        default_batch_fetch_size: 100
     generate-ddl: true
   # Disable flyway
   flyway:


### PR DESCRIPTION
## DONE
- Querydsl 추가 (빌드시 `QUser`, `QFriend` 등 Q클래스가 자동으로 추가)
- `JPAQueryFactory` 생성 위해 `global.config.QuerydslConfig.java` 추가
- `hibernate.default_batch_fetch_size` 설정 (현재 `100`, 필요시 maximum `1000`까지 연장)으로 컬렉션 조회 (ToMany) 성능 개선
### 친구 요청 API
- Querydsl 이용해 동적 쿼리 생성, fetch join으로 N+1 문제 개선
  - 친구 요청 API의 경우 GET 요청에 대해 쿼리 수가 1+N번에서 1번으로 줄어듦
- `org.springframework.data.support.PageableExecutionUtils` 이용해 필요할 때만 count 쿼리 날리도록 해 성능 개선 ([참고](https://jddng.tistory.com/345))

## TODO
- Querydsl 더 알아보고 best practice 적용
- Filtering 추가
- `local` 프로필일 때 H2 데이터베이스 사용 -> 편의상 환경변수로 각자 등록하는 것으로 통일.