### PR TITLE
TokenValidationResponseDto에 is 접두사 붙이기

### DIFF
--- a/src/main/java/com/techeer/f5/jmtmonster/domain/oauth/controller/TokenValidationController.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/oauth/controller/TokenValidationController.java
@@ -5,6 +5,9 @@ import com.techeer.f5.jmtmonster.domain.oauth.service.TokenValidationService;
 import com.techeer.f5.jmtmonster.domain.user.domain.User;
 import com.techeer.f5.jmtmonster.domain.user.dto.UserDto;
 import com.techeer.f5.jmtmonster.domain.user.dto.UserMapper;
+import java.util.UUID;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,10 +15,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -31,7 +30,7 @@ public class TokenValidationController {
         if (user == null) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
                     .body(TokenValidationResponseDto.builder()
-                            .success(false)
+                            .isSuccess(false)
                             .user(null)
                             .build());
         }
@@ -40,7 +39,7 @@ public class TokenValidationController {
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(TokenValidationResponseDto.builder()
-                        .success(true)
+                        .isSuccess(true)
                         .user(userDto)
                         .build());
     }

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/oauth/dto/TokenValidationResponseDto.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/oauth/dto/TokenValidationResponseDto.java
@@ -1,7 +1,10 @@
 package com.techeer.f5.jmtmonster.domain.oauth.dto;
 
 import com.techeer.f5.jmtmonster.domain.user.dto.UserDto;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.lang.Nullable;
 
 @Getter
@@ -9,7 +12,8 @@ import org.springframework.lang.Nullable;
 @NoArgsConstructor
 @Builder
 public class TokenValidationResponseDto {
-    private boolean success;
+
+    private Boolean isSuccess;
 
     @Nullable
     private UserDto user;


### PR DESCRIPTION
## ABOUT
프론트엔드에서 token validation 과정에서 `isSuccess`를 필요로 하는데 백엔드에서는 `success`를 반환하여 로그인에 실패하는 문제가 있었다.

## DONE
`TokenValidationResponseDto`의 `boolean success`를 `Boolean isSuccess` 로, 참조 타입인 `Boolean` 타입 및 is 접두사를 붙은 변수 이름으로 변경.

Related: #36 

