### PR TITLE
S3 Manager API 테스트 코드 리팩토링 및 문서화 문제 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,7 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok:1.18.22'
     implementation 'com.aventrix.jnanoid:jnanoid:2.0.0'
     testImplementation 'io.findify:s3mock_2.13:0.2.6'
+    implementation 'com.google.guava:guava:r05'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/techeer/f5/jmtmonster/s3/util/S3Manager.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/s3/util/S3Manager.java
@@ -66,7 +66,6 @@ public class S3Manager {
 
     // 로컬에 파일 업로드 하기
     private Optional<File> convert(MultipartFile file) throws IOException {
-//        File convertFile = new File(System.getProperty("user.dir") + "/" + file.getOriginalFilename());
         File convertFile = new File( Files.createTempDir().getAbsolutePath() + "/" + file.getOriginalFilename());
         if (convertFile.createNewFile()) { // 바로 위에서 지정한 경로에 File이 생성됨 (경로가 잘못되었다면 생성 불가능)
             try (FileOutputStream fos = new FileOutputStream(convertFile)) { // FileOutputStream 데이터를 파일에 바이트 스트림으로 저장하기 위함

--- a/src/main/java/com/techeer/f5/jmtmonster/s3/util/S3Manager.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/s3/util/S3Manager.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.aventrix.jnanoid.jnanoid.NanoIdUtils;
+import com.google.common.io.Files;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -65,7 +66,8 @@ public class S3Manager {
 
     // 로컬에 파일 업로드 하기
     private Optional<File> convert(MultipartFile file) throws IOException {
-        File convertFile = new File(System.getProperty("user.dir") + "/" + file.getOriginalFilename());
+//        File convertFile = new File(System.getProperty("user.dir") + "/" + file.getOriginalFilename());
+        File convertFile = new File( Files.createTempDir().getAbsolutePath() + "/" + file.getOriginalFilename());
         if (convertFile.createNewFile()) { // 바로 위에서 지정한 경로에 File이 생성됨 (경로가 잘못되었다면 생성 불가능)
             try (FileOutputStream fos = new FileOutputStream(convertFile)) { // FileOutputStream 데이터를 파일에 바이트 스트림으로 저장하기 위함
                 fos.write(file.getBytes());

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -24,10 +24,10 @@ oauth:
 cloud:
   aws:
     credentials:
-      accessKey: ''
-      secretKey: ''
+      accessKey: ${aws-s3-access-key}
+      secretKey: ${aws-s3-secret-key}
     s3:
-      bucket: ''
+      bucket: ${aws-s3-bucket-name}
     region:
       static: ap-northeast-2
     stack:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -11,6 +11,7 @@ spring:
     hibernate.dialect: org.hibernate.dialect.MariaDBDialect
     database-platform: org.hibernate.dialect.H2Dialect
     hibernate.ddl-auto: create-drop
+    default_batch_fetch_size: 100
 
 oauth:
   back-end-base-url: http://localhost:8000

--- a/src/test/java/com/techeer/f5/jmtmonster/domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/techeer/f5/jmtmonster/domain/review/controller/ReviewControllerTest.java
@@ -54,7 +54,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ExtendWith(SpringExtension.class)
 @AutoConfigureMockMvc(addFilters = false)
 @AutoConfigureRestDocs
-@ActiveProfiles(profiles = {"secret", "test", "disable-auth"})
+@ActiveProfiles(profiles = {"test", "disable-auth"})
 @Import({ReviewMapper.class, UserMapper.class})
 @DisplayName("리뷰 API")
 public class ReviewControllerTest {

--- a/src/test/java/com/techeer/f5/jmtmonster/domain/review/controller/S3ControllerTest.java
+++ b/src/test/java/com/techeer/f5/jmtmonster/domain/review/controller/S3ControllerTest.java
@@ -47,7 +47,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ExtendWith(SpringExtension.class)
 @AutoConfigureMockMvc(addFilters = false)
 @AutoConfigureRestDocs
-@ActiveProfiles(profiles = {"test","secret","disable-auth"})
+@ActiveProfiles(profiles = {"test","disable-auth"})
 @Import({S3Mapper.class, UserMapper.class})
 @DisplayName("S3 API")
 public class S3ControllerTest {

--- a/src/test/java/com/techeer/f5/jmtmonster/s3/LocalStackS3Config.java
+++ b/src/test/java/com/techeer/f5/jmtmonster/s3/LocalStackS3Config.java
@@ -1,0 +1,29 @@
+package com.techeer.f5.jmtmonster.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3;
+
+@TestConfiguration
+public class LocalStackS3Config {
+    DockerImageName localstackImage = DockerImageName.parse("localstack/localstack");
+
+    @Bean(initMethod = "start", destroyMethod = "stop")
+    public LocalStackContainer localStackContainer() {
+        return new LocalStackContainer(localstackImage)
+                .withServices(S3);
+    }
+
+    @Bean
+    public AmazonS3 amazonS3(LocalStackContainer localStackContainer) {
+        return AmazonS3ClientBuilder.standard()
+                .withEndpointConfiguration(localStackContainer.getEndpointConfiguration(S3))
+                .withCredentials(localStackContainer.getDefaultCredentialsProvider())
+                .build();
+    }
+}

--- a/src/test/java/com/techeer/f5/jmtmonster/s3/S3ManagerTest.java
+++ b/src/test/java/com/techeer/f5/jmtmonster/s3/S3ManagerTest.java
@@ -72,7 +72,4 @@ public class S3ManagerTest {
         // then
         s3Manager.delete(actualFilename);
     }
-
-
-
 }

--- a/src/test/java/com/techeer/f5/jmtmonster/s3/S3ManagerTest.java
+++ b/src/test/java/com/techeer/f5/jmtmonster/s3/S3ManagerTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@ActiveProfiles(profiles = {"test", "secret"})
+@ActiveProfiles(profiles = {"test"})
 @Import(S3MockConfig.class)
 public class S3ManagerTest {
 
@@ -59,7 +59,7 @@ public class S3ManagerTest {
 
     @Test
     @DisplayName("S3 이미지 삭제 테스트")
-    void S3ManagerTest() throws IOException {
+    void deleteTest() throws IOException {
         // given
         String file2 = "mock2.png";
         MockMultipartFile mockMultipartFile2 = new MockMultipartFile("file", file,

--- a/src/test/java/com/techeer/f5/jmtmonster/s3/S3MockConfig.java
+++ b/src/test/java/com/techeer/f5/jmtmonster/s3/S3MockConfig.java
@@ -23,7 +23,7 @@ public class S3MockConfig {
     //S3Mock을 빌드할때 포트나 메모리에 저장할 지 실제로 저장할 지 같은 것 등등을 설정 가능하다.
     @Bean
     public S3Mock s3Mock() {
-        return new S3Mock.Builder().withPort(8001).withInMemoryBackend().build();
+        return new S3Mock.Builder().withPort(8091).withInMemoryBackend().build();
     }
 
     //위에서 작성한 S3Mock을 주입받는 Bean을 작성하였다.
@@ -33,7 +33,7 @@ public class S3MockConfig {
     @Primary
     public AmazonS3 amazonS3(S3Mock s3Mock){
         s3Mock.start();
-        AwsClientBuilder.EndpointConfiguration endpoint = new AwsClientBuilder.EndpointConfiguration("http://localhost:8001", region);
+        AwsClientBuilder.EndpointConfiguration endpoint = new AwsClientBuilder.EndpointConfiguration("http://localhost:8091", region);
         AmazonS3 client = AmazonS3ClientBuilder
                 .standard()
                 .withPathStyleAccessEnabled(true)


### PR DESCRIPTION
## DONE
* S3Mock의 포트 번호 충돌 방지를 위해 포트 번호 변경 (8001 -> 8091)
* S3 upload API에서 파일 이름 충돌을 방지하기 위해 temporary file 사용
* 테스트 코드에서 secret profile 제거

## COMMENT
기존의 S3 API를 리팩토링하였습니다. 또한 S3 API가 Restdocs로 문서화 되지 않던 문제도 해결하였습니다.
gradle로 빌드하실 때 노션에 있는 secret 값 환경 변수들 같이 넣어서 실행하시면 문서화 모두 문제 없이 성공합니다.

![image](https://user-images.githubusercontent.com/57928967/177373059-1444c0c0-0c67-487e-872c-c9ebb176786e.png)
