### PR TITLE
사용자 프로필 API 추가

### DIFF
--- a/src/main/java/com/techeer/f5/jmtmonster/domain/friend/dao/FriendQueryRepositoryImpl.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/friend/dao/FriendQueryRepositoryImpl.java
@@ -47,8 +47,10 @@ public class FriendQueryRepositoryImpl implements FriendQueryRepository {
     private JPAQuery<Long> getCount(QUser fromUser, QUser toUser, UUID fromUserIdCond,
             UUID toUserIdCond) {
         return jpaQueryFactory
-                .select(friendRequest.count())
-                .from(friendRequest)
+                .select(friend.count())
+                .from(friend)
+                .innerJoin(friend.fromUser, fromUser)
+                .innerJoin(friend.toUser, toUser)
                 .where(fromUserIdEq(fromUser, fromUserIdCond),
                         toUserIdEq(toUser, toUserIdCond));
     }

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/friend/dao/FriendQueryRepositoryImpl.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/friend/dao/FriendQueryRepositoryImpl.java
@@ -2,12 +2,12 @@ package com.techeer.f5.jmtmonster.domain.friend.dao;
 
 import static com.techeer.f5.jmtmonster.domain.friend.domain.QFriend.friend;
 import static com.techeer.f5.jmtmonster.domain.friend.domain.QFriendRequest.friendRequest;
-import static com.techeer.f5.jmtmonster.domain.user.domain.QUser.user;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.techeer.f5.jmtmonster.domain.friend.domain.Friend;
+import com.techeer.f5.jmtmonster.domain.user.domain.QUser;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -24,34 +24,38 @@ public class FriendQueryRepositoryImpl implements FriendQueryRepository {
 
     @Override
     public Page<Friend> searchFriends(Pageable pageable, UUID fromUserIdCond, UUID toUserIdCond) {
+        QUser fromUser = new QUser("fromUser");
+        QUser toUser = new QUser("toUser");
+
         List<Friend> query = jpaQueryFactory
                 .selectFrom(friend)
-                .where(fromUserIdEq(fromUserIdCond),
-                        toUserIdEq(toUserIdCond))
-                .innerJoin(friend.fromUser, user)
+                .where(fromUserIdEq(fromUser, fromUserIdCond),
+                        toUserIdEq(toUser, toUserIdCond))
+                .innerJoin(friend.fromUser, fromUser)
                 .fetchJoin()
-                .innerJoin(friend.toUser, user)
+                .innerJoin(friend.toUser, toUser)
                 .fetchJoin()
                 .fetch();
 
-        JPAQuery<Long> countQuery = getCount(fromUserIdCond, toUserIdCond);
+        JPAQuery<Long> countQuery = getCount(fromUser, toUser, fromUserIdCond, toUserIdCond);
 
         return PageableExecutionUtils.getPage(query, pageable, countQuery::fetchOne);
     }
 
-    private JPAQuery<Long> getCount(UUID fromUserIdCond, UUID toUserIdCond) {
+    private JPAQuery<Long> getCount(QUser fromUser, QUser toUser, UUID fromUserIdCond,
+            UUID toUserIdCond) {
         return jpaQueryFactory
                 .select(friendRequest.count())
                 .from(friendRequest)
-                .where(fromUserIdEq(fromUserIdCond),
-                        toUserIdEq(toUserIdCond));
+                .where(fromUserIdEq(fromUser, fromUserIdCond),
+                        toUserIdEq(toUser, toUserIdCond));
     }
 
-    private BooleanExpression fromUserIdEq(UUID fromUserIdCond) {
-        return fromUserIdCond != null ? friend.fromUser.id.eq(fromUserIdCond) : null;
+    private BooleanExpression fromUserIdEq(QUser fromUser, UUID fromUserIdCond) {
+        return fromUserIdCond != null ? fromUser.id.eq(fromUserIdCond) : null;
     }
 
-    private BooleanExpression toUserIdEq(UUID toUserIdCond) {
-        return toUserIdCond != null ? friend.toUser.id.eq(toUserIdCond) : null;
+    private BooleanExpression toUserIdEq(QUser toUser, UUID toUserIdCond) {
+        return toUserIdCond != null ? toUser.id.eq(toUserIdCond) : null;
     }
 }

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/friend/dao/FriendQueryRepositoryImpl.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/friend/dao/FriendQueryRepositoryImpl.java
@@ -35,6 +35,8 @@ public class FriendQueryRepositoryImpl implements FriendQueryRepository {
                 .fetchJoin()
                 .innerJoin(friend.toUser, toUser)
                 .fetchJoin()
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
                 .fetch();
 
         JPAQuery<Long> countQuery = getCount(fromUser, toUser, fromUserIdCond, toUserIdCond);

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/friend/dao/FriendRequestQueryRepositoryImpl.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/friend/dao/FriendRequestQueryRepositoryImpl.java
@@ -1,13 +1,13 @@
 package com.techeer.f5.jmtmonster.domain.friend.dao;
 
 import static com.techeer.f5.jmtmonster.domain.friend.domain.QFriendRequest.friendRequest;
-import static com.techeer.f5.jmtmonster.domain.user.domain.QUser.user;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.techeer.f5.jmtmonster.domain.friend.domain.FriendRequest;
 import com.techeer.f5.jmtmonster.domain.friend.domain.FriendRequestStatus;
+import com.techeer.f5.jmtmonster.domain.user.domain.QUser;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -25,37 +25,45 @@ public class FriendRequestQueryRepositoryImpl implements FriendRequestQueryRepos
     @Override
     public Page<FriendRequest> searchFriendRequests(Pageable pageable, UUID fromUserIdCond,
             UUID toUserIdCond, FriendRequestStatus statusCond) {
+        QUser fromUser = new QUser("fromUser");
+        QUser toUser = new QUser("toUser");
+
         List<FriendRequest> query = jpaQueryFactory
                 .selectFrom(friendRequest)
-                .innerJoin(friendRequest.fromUser, user)
+                .innerJoin(friendRequest.fromUser, fromUser)
                 .fetchJoin()
-                .innerJoin(friendRequest.toUser, user)
+                .innerJoin(friendRequest.toUser, toUser)
                 .fetchJoin()
-                .where(fromUserIdEq(fromUserIdCond),
-                        toUserIdEq(toUserIdCond),
+                .where(fromUserIdEq(fromUser, fromUserIdCond),
+                        toUserIdEq(toUser, toUserIdCond),
                         statusEq(statusCond))
                 .fetch();
 
-        JPAQuery<Long> countQuery = getCount();
+        JPAQuery<Long> countQuery = getCount(fromUser, toUser, fromUserIdCond, toUserIdCond,
+                statusCond);
 
         return PageableExecutionUtils.getPage(query, pageable, countQuery::fetchOne);
     }
 
-    private BooleanExpression fromUserIdEq(UUID fromUserIdCond) {
-        return fromUserIdCond != null ? friendRequest.fromUser.id.eq(fromUserIdCond) : null;
+    private BooleanExpression fromUserIdEq(QUser fromUser, UUID fromUserIdCond) {
+        return fromUserIdCond != null ? fromUser.id.eq(fromUserIdCond) : null;
     }
 
-    private BooleanExpression toUserIdEq(UUID toUserIdCond) {
-        return toUserIdCond != null ? friendRequest.toUser.id.eq(toUserIdCond) : null;
+    private BooleanExpression toUserIdEq(QUser toUser, UUID toUserIdCond) {
+        return toUserIdCond != null ? toUser.id.eq(toUserIdCond) : null;
     }
 
     private BooleanExpression statusEq(FriendRequestStatus statusCond) {
         return statusCond != null ? friendRequest.status.eq(statusCond) : null;
     }
 
-    private JPAQuery<Long> getCount() {
+    private JPAQuery<Long> getCount(QUser fromUser, QUser toUser, UUID fromUserIdCond,
+            UUID toUserIdCond, FriendRequestStatus statusCond) {
         return jpaQueryFactory
                 .select(friendRequest.count())
+                .where(fromUserIdEq(fromUser, fromUserIdCond),
+                        toUserIdEq(toUser, toUserIdCond),
+                        statusEq(statusCond))
                 .from(friendRequest);
     }
 }

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/friend/dao/FriendRequestQueryRepositoryImpl.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/friend/dao/FriendRequestQueryRepositoryImpl.java
@@ -63,9 +63,11 @@ public class FriendRequestQueryRepositoryImpl implements FriendRequestQueryRepos
             UUID toUserIdCond, FriendRequestStatus statusCond) {
         return jpaQueryFactory
                 .select(friendRequest.count())
+                .from(friendRequest)
+                .innerJoin(friendRequest.fromUser, fromUser)
+                .innerJoin(friendRequest.toUser, toUser)
                 .where(fromUserIdEq(fromUser, fromUserIdCond),
                         toUserIdEq(toUser, toUserIdCond),
-                        statusEq(statusCond))
-                .from(friendRequest);
+                        statusEq(statusCond));
     }
 }

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/friend/dao/FriendRequestQueryRepositoryImpl.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/friend/dao/FriendRequestQueryRepositoryImpl.java
@@ -37,6 +37,8 @@ public class FriendRequestQueryRepositoryImpl implements FriendRequestQueryRepos
                 .where(fromUserIdEq(fromUser, fromUserIdCond),
                         toUserIdEq(toUser, toUserIdCond),
                         statusEq(statusCond))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
                 .fetch();
 
         JPAQuery<Long> countQuery = getCount(fromUser, toUser, fromUserIdCond, toUserIdCond,

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/user/controller/UserProfileController.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/user/controller/UserProfileController.java
@@ -1,0 +1,33 @@
+package com.techeer.f5.jmtmonster.domain.user.controller;
+
+import com.techeer.f5.jmtmonster.domain.user.domain.User;
+import com.techeer.f5.jmtmonster.domain.user.dto.BasicUserResponseDto;
+import com.techeer.f5.jmtmonster.domain.user.dto.UserMapper;
+import com.techeer.f5.jmtmonster.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserProfileController {
+
+    private final UserService userService;
+    private final UserMapper userMapper;
+
+    @GetMapping
+    public ResponseEntity<Page<BasicUserResponseDto>> getUserProfile(
+            @PageableDefault Pageable pageable, @RequestParam("email") String email) {
+        Page<User> result = userService.searchByEmail(pageable, email);
+        Page<BasicUserResponseDto> response = result.map(userMapper::toBasicUserResponseDto);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/user/repository/UserQueryRepository.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/user/repository/UserQueryRepository.java
@@ -1,0 +1,10 @@
+package com.techeer.f5.jmtmonster.domain.user.repository;
+
+import com.techeer.f5.jmtmonster.domain.user.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface UserQueryRepository {
+
+    Page<User> searchByEmail(Pageable pageable, String emailCond);
+}

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/user/repository/UserQueryRepositoryImpl.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/user/repository/UserQueryRepositoryImpl.java
@@ -1,0 +1,39 @@
+package com.techeer.f5.jmtmonster.domain.user.repository;
+
+import static com.techeer.f5.jmtmonster.domain.user.domain.QUser.user;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.techeer.f5.jmtmonster.domain.user.domain.User;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class UserQueryRepositoryImpl implements UserQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<User> searchByEmail(Pageable pageable, String emailCond) {
+        List<User> query = jpaQueryFactory
+                .selectFrom(user)
+                .where(user.email.eq(emailCond))
+                .fetch();
+
+        JPAQuery<Long> countQuery = getCount(emailCond);
+
+        return PageableExecutionUtils.getPage(query, pageable, countQuery::fetchOne);
+    }
+
+    private JPAQuery<Long> getCount(String emailCond) {
+        return jpaQueryFactory
+                .select(user.count())
+                .from(user)
+                .where(user.email.eq(emailCond));
+    }
+}

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/user/repository/UserRepository.java
@@ -1,20 +1,18 @@
 package com.techeer.f5.jmtmonster.domain.user.repository;
 
-import com.techeer.f5.jmtmonster.domain.oauth.domain.AuthProvider;
 import com.techeer.f5.jmtmonster.domain.user.domain.User;
+import java.util.Optional;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
-import java.util.UUID;
-
 @Repository
-public interface UserRepository extends JpaRepository<User, UUID> {
+public interface UserRepository extends JpaRepository<User, UUID>, UserQueryRepository {
 
     Optional<User> getUserByName(String name);
-    Optional<User> getUserByEmail(String email);
 
+    Optional<User> getUserByEmail(String email);
 
     @Transactional
     default User build(String name, String email) {

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/user/service/UserService.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/user/service/UserService.java
@@ -1,24 +1,23 @@
 package com.techeer.f5.jmtmonster.domain.user.service;
 
 import com.techeer.f5.jmtmonster.domain.oauth.domain.PersistentToken;
-import com.techeer.f5.jmtmonster.domain.user.dto.UserResponseDto;
 import com.techeer.f5.jmtmonster.domain.oauth.repository.PersistentTokenRepository;
 import com.techeer.f5.jmtmonster.domain.user.domain.User;
 import com.techeer.f5.jmtmonster.domain.user.dto.ExtraUserInfoRequestDto;
 import com.techeer.f5.jmtmonster.domain.user.dto.UserDto;
 import com.techeer.f5.jmtmonster.domain.user.dto.UserMapper;
+import com.techeer.f5.jmtmonster.domain.user.dto.UserResponseDto;
 import com.techeer.f5.jmtmonster.domain.user.repository.UserRepository;
-import com.techeer.f5.jmtmonster.global.error.exception.CustomStatusException;
-import com.techeer.f5.jmtmonster.global.error.exception.ErrorCode;
 import com.techeer.f5.jmtmonster.global.error.exception.NotAuthorizedException;
 import com.techeer.f5.jmtmonster.global.error.exception.ResourceNotFoundException;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-
-import javax.servlet.http.HttpServletRequest;
 import java.util.Optional;
 import java.util.UUID;
+import javax.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -48,6 +47,10 @@ public class UserService {
 
     public Optional<User> findUserById(UUID id) {
         return userRepository.findById(id);
+    }
+
+    public Page<User> searchByEmail(Pageable pageable, String email) {
+        return userRepository.searchByEmail(pageable, email);
     }
 
     public Optional<User> findUserByTokenId(UUID tokenId) {

--- a/src/main/resources/static/docs/openapi3.json
+++ b/src/main/resources/static/docs/openapi3.json
@@ -28,7 +28,7 @@
                 },
                 "examples" : {
                   "friend-request-get-list" : {
-                    "value" : "{\n  \"content\" : [ {\n    \"id\" : \"acfe4cd7-8996-456f-84c0-6f72294a3a30\",\n    \"fromUser\" : {\n      \"id\" : \"37b7b8e0-1b85-4d34-85d7-bfa8eb0f66a7\",\n      \"name\" : \"FromUser\",\n      \"email\" : \"test@jmt-monster.com\",\n      \"nickname\" : \"FromUser\",\n      \"imageUrl\" : \"https://profile.example.com/from-user\"\n    },\n    \"toUser\" : {\n      \"id\" : \"e835b71c-3b38-4b93-96ac-ef70be7cd354\",\n      \"name\" : \"ToUser\",\n      \"email\" : \"test@jmt-monster.com\",\n      \"nickname\" : \"ToUser\",\n      \"imageUrl\" : \"https://profile.example.com/to-user\"\n    },\n    \"status\" : \"PENDING\"\n  } ],\n  \"pageable\" : {\n    \"sort\" : {\n      \"empty\" : true,\n      \"sorted\" : false,\n      \"unsorted\" : true\n    },\n    \"offset\" : 0,\n    \"pageNumber\" : 0,\n    \"pageSize\" : 10,\n    \"paged\" : true,\n    \"unpaged\" : false\n  },\n  \"totalPages\" : 1,\n  \"totalElements\" : 1,\n  \"last\" : true,\n  \"number\" : 0,\n  \"sort\" : {\n    \"empty\" : true,\n    \"sorted\" : false,\n    \"unsorted\" : true\n  },\n  \"size\" : 10,\n  \"numberOfElements\" : 1,\n  \"first\" : true,\n  \"empty\" : false\n}"
+                    "value" : "{\n  \"content\" : [ {\n    \"id\" : \"382d4131-d0c5-41b9-9271-5c26dd5337ee\",\n    \"fromUser\" : {\n      \"id\" : \"2ee76b23-d47a-4e9e-a4bb-062f99c541cc\",\n      \"name\" : \"FromUser\",\n      \"email\" : \"test@jmt-monster.com\",\n      \"nickname\" : \"FromUser\",\n      \"imageUrl\" : \"https://profile.example.com/from-user\"\n    },\n    \"toUser\" : {\n      \"id\" : \"558622ea-063a-42d4-adbc-3a2822651b06\",\n      \"name\" : \"ToUser\",\n      \"email\" : \"test@jmt-monster.com\",\n      \"nickname\" : \"ToUser\",\n      \"imageUrl\" : \"https://profile.example.com/to-user\"\n    },\n    \"status\" : \"PENDING\"\n  } ],\n  \"pageable\" : {\n    \"sort\" : {\n      \"empty\" : true,\n      \"sorted\" : false,\n      \"unsorted\" : true\n    },\n    \"offset\" : 0,\n    \"pageNumber\" : 0,\n    \"pageSize\" : 10,\n    \"paged\" : true,\n    \"unpaged\" : false\n  },\n  \"totalPages\" : 1,\n  \"totalElements\" : 1,\n  \"last\" : true,\n  \"size\" : 10,\n  \"sort\" : {\n    \"empty\" : true,\n    \"sorted\" : false,\n    \"unsorted\" : true\n  },\n  \"number\" : 0,\n  \"numberOfElements\" : 1,\n  \"first\" : true,\n  \"empty\" : false\n}"
                   }
                 }
               }
@@ -49,7 +49,7 @@
               },
               "examples" : {
                 "friend-request-create" : {
-                  "value" : "{\n  \"fromUserId\" : \"e9ee5360-8478-4c9b-b6d2-9ee86b83fb83\",\n  \"toUserId\" : \"f365b7db-3118-44ab-8476-5c76b5021736\"\n}"
+                  "value" : "{\n  \"fromUserId\" : \"d811543c-24de-4126-9782-c4b3502f09f4\",\n  \"toUserId\" : \"9e96bb81-e7c4-4615-b94c-a12eaeaa003a\"\n}"
                 }
               }
             }
@@ -61,11 +61,11 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/api-v1-friend-requests-id529653109"
+                  "$ref" : "#/components/schemas/api-v1-friend-requests529653109"
                 },
                 "examples" : {
                   "friend-request-create" : {
-                    "value" : "{\n  \"id\" : \"1a3fc148-e3f0-4569-9c17-1c39fe1750d1\",\n  \"fromUser\" : {\n    \"id\" : \"e9ee5360-8478-4c9b-b6d2-9ee86b83fb83\",\n    \"name\" : \"FromUser\",\n    \"email\" : \"test@jmt-monster.com\",\n    \"nickname\" : \"FromUser\",\n    \"imageUrl\" : \"https://profile.example.com/from-user\"\n  },\n  \"toUser\" : {\n    \"id\" : \"f365b7db-3118-44ab-8476-5c76b5021736\",\n    \"name\" : \"ToUser\",\n    \"email\" : \"test@jmt-monster.com\",\n    \"nickname\" : \"ToUser\",\n    \"imageUrl\" : \"https://profile.example.com/to-user\"\n  },\n  \"status\" : \"PENDING\",\n  \"_links\" : {\n    \"list\" : {\n      \"href\" : \"http://localhost:8080/api/v1/friend-requests\"\n    },\n    \"self\" : {\n      \"href\" : \"http://localhost:8080/api/v1/friend-requests/1a3fc148-e3f0-4569-9c17-1c39fe1750d1\"\n    },\n    \"update\" : {\n      \"href\" : \"http://localhost:8080/api/v1/friend-requests/1a3fc148-e3f0-4569-9c17-1c39fe1750d1\"\n    },\n    \"delete\" : {\n      \"href\" : \"http://localhost:8080/api/v1/friend-requests/1a3fc148-e3f0-4569-9c17-1c39fe1750d1\"\n    }\n  }\n}"
+                    "value" : "{\n  \"id\" : \"34714d12-3152-4409-9080-05e83050a0cb\",\n  \"fromUser\" : {\n    \"id\" : \"d811543c-24de-4126-9782-c4b3502f09f4\",\n    \"name\" : \"FromUser\",\n    \"email\" : \"test@jmt-monster.com\",\n    \"nickname\" : \"FromUser\",\n    \"imageUrl\" : \"https://profile.example.com/from-user\"\n  },\n  \"toUser\" : {\n    \"id\" : \"9e96bb81-e7c4-4615-b94c-a12eaeaa003a\",\n    \"name\" : \"ToUser\",\n    \"email\" : \"test@jmt-monster.com\",\n    \"nickname\" : \"ToUser\",\n    \"imageUrl\" : \"https://profile.example.com/to-user\"\n  },\n  \"status\" : \"PENDING\",\n  \"_links\" : {\n    \"list\" : {\n      \"href\" : \"http://localhost:8080/api/v1/friend-requests\"\n    },\n    \"self\" : {\n      \"href\" : \"http://localhost:8080/api/v1/friend-requests/34714d12-3152-4409-9080-05e83050a0cb\"\n    },\n    \"update\" : {\n      \"href\" : \"http://localhost:8080/api/v1/friend-requests/34714d12-3152-4409-9080-05e83050a0cb\"\n    },\n    \"delete\" : {\n      \"href\" : \"http://localhost:8080/api/v1/friend-requests/34714d12-3152-4409-9080-05e83050a0cb\"\n    }\n  }\n}"
                   }
                 }
               }
@@ -115,7 +115,7 @@
                 },
                 "examples" : {
                   "friend-get-list" : {
-                    "value" : "{\n  \"content\" : [ {\n    \"id\" : \"dc69c12a-425c-4dd6-9447-8b7a9e49d15b\",\n    \"fromUser\" : {\n      \"id\" : \"2ea691d3-7e92-44cb-ba57-cf4748cdd839\",\n      \"name\" : \"FromUser\",\n      \"email\" : \"test@jmt-monster.com\",\n      \"nickname\" : \"FromUser\",\n      \"imageUrl\" : \"https://profile.example.com/from-user\"\n    },\n    \"toUser\" : {\n      \"id\" : \"1cb01781-5323-448a-96ce-cdcbb35f94fb\",\n      \"name\" : \"ToUser\",\n      \"email\" : \"test@jmt-monster.com\",\n      \"nickname\" : \"ToUser\",\n      \"imageUrl\" : \"https://profile.example.com/to-user\"\n    }\n  } ],\n  \"pageable\" : {\n    \"sort\" : {\n      \"empty\" : true,\n      \"sorted\" : false,\n      \"unsorted\" : true\n    },\n    \"offset\" : 0,\n    \"pageNumber\" : 0,\n    \"pageSize\" : 10,\n    \"paged\" : true,\n    \"unpaged\" : false\n  },\n  \"totalPages\" : 1,\n  \"totalElements\" : 1,\n  \"last\" : true,\n  \"number\" : 0,\n  \"sort\" : {\n    \"empty\" : true,\n    \"sorted\" : false,\n    \"unsorted\" : true\n  },\n  \"size\" : 10,\n  \"numberOfElements\" : 1,\n  \"first\" : true,\n  \"empty\" : false\n}"
+                    "value" : "{\n  \"content\" : [ {\n    \"id\" : \"15a0254a-28bf-45f9-bb73-236be0d492c5\",\n    \"fromUser\" : {\n      \"id\" : \"28a343b5-8f58-4486-9794-22cab3f933a9\",\n      \"name\" : \"FromUser\",\n      \"email\" : \"test@jmt-monster.com\",\n      \"nickname\" : \"FromUser\",\n      \"imageUrl\" : \"https://profile.example.com/from-user\"\n    },\n    \"toUser\" : {\n      \"id\" : \"b324f643-36be-4196-a799-1b4663d431bf\",\n      \"name\" : \"ToUser\",\n      \"email\" : \"test@jmt-monster.com\",\n      \"nickname\" : \"ToUser\",\n      \"imageUrl\" : \"https://profile.example.com/to-user\"\n    }\n  } ],\n  \"pageable\" : {\n    \"sort\" : {\n      \"empty\" : true,\n      \"sorted\" : false,\n      \"unsorted\" : true\n    },\n    \"offset\" : 0,\n    \"pageNumber\" : 0,\n    \"pageSize\" : 10,\n    \"paged\" : true,\n    \"unpaged\" : false\n  },\n  \"totalPages\" : 1,\n  \"totalElements\" : 1,\n  \"last\" : true,\n  \"size\" : 10,\n  \"sort\" : {\n    \"empty\" : true,\n    \"sorted\" : false,\n    \"unsorted\" : true\n  },\n  \"number\" : 0,\n  \"numberOfElements\" : 1,\n  \"first\" : true,\n  \"empty\" : false\n}"
                   }
                 }
               }
@@ -140,7 +140,7 @@
                 },
                 "examples" : {
                   "hello-get" : {
-                    "value" : "{\n  \"value\" : \"hello\",\n  \"success\" : true,\n  \"createdOn\" : \"2022-06-22T22:59:29.99012\"\n}"
+                    "value" : "{\n  \"value\" : \"hello\",\n  \"success\" : true,\n  \"createdOn\" : \"2022-07-09T12:03:23.996112\"\n}"
                   }
                 }
               }
@@ -177,7 +177,7 @@
                 },
                 "examples" : {
                   "hello-create" : {
-                    "value" : "{\n  \"value\" : \"hello example1\",\n  \"success\" : true,\n  \"createdOn\" : \"2022-06-22T22:59:29.944766\"\n}"
+                    "value" : "{\n  \"value\" : \"hello example1\",\n  \"success\" : true,\n  \"createdOn\" : \"2022-07-09T12:03:23.92818\"\n}"
                   }
                 }
               }
@@ -234,6 +234,40 @@
         }
       }
     },
+    "/api/v1/users" : {
+      "get" : {
+        "tags" : [ "api" ],
+        "summary" : "사용자 프로필 조회",
+        "description" : "사용자 프로필을 이메일로 조회합니다.",
+        "operationId" : "user-profile-search",
+        "parameters" : [ {
+          "name" : "email",
+          "in" : "query",
+          "description" : "사용자 이메일",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "200",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/api-v1-users701179906"
+                },
+                "examples" : {
+                  "user-profile-search" : {
+                    "value" : "{\n  \"content\" : [ {\n    \"id\" : \"44b31a0f-a1f3-4b27-b684-d011ec2bb462\",\n    \"name\" : \"Testuser\",\n    \"email\" : \"testuser@example.com\",\n    \"nickname\" : \"Testuser\",\n    \"imageUrl\" : \"https://profile.example.com/testuser\"\n  } ],\n  \"pageable\" : {\n    \"sort\" : {\n      \"empty\" : true,\n      \"sorted\" : false,\n      \"unsorted\" : true\n    },\n    \"offset\" : 0,\n    \"pageNumber\" : 0,\n    \"pageSize\" : 10,\n    \"paged\" : true,\n    \"unpaged\" : false\n  },\n  \"totalPages\" : 1,\n  \"totalElements\" : 1,\n  \"last\" : true,\n  \"size\" : 10,\n  \"sort\" : {\n    \"empty\" : true,\n    \"sorted\" : false,\n    \"unsorted\" : true\n  },\n  \"number\" : 0,\n  \"numberOfElements\" : 1,\n  \"first\" : true,\n  \"empty\" : false\n}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/friend-requests/{id}" : {
       "get" : {
         "tags" : [ "api" ],
@@ -255,11 +289,11 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/api-v1-friend-requests-id529653109"
+                  "$ref" : "#/components/schemas/api-v1-friend-requests529653109"
                 },
                 "examples" : {
                   "friend-request-get-one" : {
-                    "value" : "{\n  \"id\" : \"61cbd5b1-030d-44e3-b093-8226c4c756a0\",\n  \"fromUser\" : {\n    \"id\" : \"8cf952ba-888a-4d09-94fd-04616743fe3b\",\n    \"name\" : \"FromUser\",\n    \"email\" : \"test@jmt-monster.com\",\n    \"nickname\" : \"FromUser\",\n    \"imageUrl\" : \"https://profile.example.com/from-user\"\n  },\n  \"toUser\" : {\n    \"id\" : \"955474c3-1870-45c6-a2d7-87f584d3e0ec\",\n    \"name\" : \"ToUser\",\n    \"email\" : \"test@jmt-monster.com\",\n    \"nickname\" : \"ToUser\",\n    \"imageUrl\" : \"https://profile.example.com/to-user\"\n  },\n  \"status\" : \"PENDING\"\n}"
+                    "value" : "{\n  \"id\" : \"73aeb8be-cbd7-4b18-89bd-2f81f6244a37\",\n  \"fromUser\" : {\n    \"id\" : \"f0fac66d-5a9a-443d-95a4-5848bbbcd014\",\n    \"name\" : \"FromUser\",\n    \"email\" : \"test@jmt-monster.com\",\n    \"nickname\" : \"FromUser\",\n    \"imageUrl\" : \"https://profile.example.com/from-user\"\n  },\n  \"toUser\" : {\n    \"id\" : \"749caa7a-8fab-4e1e-a721-cc37f57ba004\",\n    \"name\" : \"ToUser\",\n    \"email\" : \"test@jmt-monster.com\",\n    \"nickname\" : \"ToUser\",\n    \"imageUrl\" : \"https://profile.example.com/to-user\"\n  },\n  \"status\" : \"PENDING\"\n}"
                   }
                 }
               }
@@ -301,11 +335,11 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/api-v1-friend-requests-id529653109"
+                  "$ref" : "#/components/schemas/api-v1-friend-requests529653109"
                 },
                 "examples" : {
                   "friend-request-update-to-create-friend" : {
-                    "value" : "{\n  \"id\" : \"b86fe300-a75d-43b5-8b4a-762d50ef2aa1\",\n  \"fromUser\" : {\n    \"id\" : \"fb7627fb-4200-4fa2-a592-ed0ca2cb5eb6\",\n    \"name\" : \"FromUser\",\n    \"email\" : \"test@jmt-monster.com\",\n    \"nickname\" : \"FromUser\",\n    \"imageUrl\" : \"https://profile.example.com/from-user\"\n  },\n  \"toUser\" : {\n    \"id\" : \"7cb5e091-07ff-4de5-a052-87665fc8f2f5\",\n    \"name\" : \"ToUser\",\n    \"email\" : \"test@jmt-monster.com\",\n    \"nickname\" : \"ToUser\",\n    \"imageUrl\" : \"https://profile.example.com/to-user\"\n  },\n  \"status\" : \"ACCEPTED\"\n}"
+                    "value" : "{\n  \"id\" : \"a0b8da52-2f03-4ecb-9c1e-9e68bc5312fd\",\n  \"fromUser\" : {\n    \"id\" : \"c2d9e008-41ca-45df-9071-1c4a3de81389\",\n    \"name\" : \"FromUser\",\n    \"email\" : \"test@jmt-monster.com\",\n    \"nickname\" : \"FromUser\",\n    \"imageUrl\" : \"https://profile.example.com/from-user\"\n  },\n  \"toUser\" : {\n    \"id\" : \"e0b5f24b-ddad-4a70-8529-c97612f52763\",\n    \"name\" : \"ToUser\",\n    \"email\" : \"test@jmt-monster.com\",\n    \"nickname\" : \"ToUser\",\n    \"imageUrl\" : \"https://profile.example.com/to-user\"\n  },\n  \"status\" : \"ACCEPTED\"\n}"
                   }
                 }
               }
@@ -339,7 +373,7 @@
                 },
                 "examples" : {
                   "friend-get-one" : {
-                    "value" : "{\n  \"id\" : \"7bf5054c-d6e0-414b-9087-8a101834c7a5\",\n  \"fromUser\" : {\n    \"id\" : \"789eaaf0-3241-4244-85b5-5fc21d61873d\",\n    \"name\" : \"FromUser\",\n    \"email\" : \"test@jmt-monster.com\",\n    \"nickname\" : \"FromUser\",\n    \"imageUrl\" : \"https://profile.example.com/from-user\"\n  },\n  \"toUser\" : {\n    \"id\" : \"68f996f4-cc0c-476e-8c55-6fbaaaa62831\",\n    \"name\" : \"ToUser\",\n    \"email\" : \"test@jmt-monster.com\",\n    \"nickname\" : \"ToUser\",\n    \"imageUrl\" : \"https://profile.example.com/to-user\"\n  }\n}"
+                    "value" : "{\n  \"id\" : \"d45533bc-75e3-4054-a88c-41ef30e03a2f\",\n  \"fromUser\" : {\n    \"id\" : \"92a4051b-66e2-48ad-90f7-6f0f9625aece\",\n    \"name\" : \"FromUser\",\n    \"email\" : \"test@jmt-monster.com\",\n    \"nickname\" : \"FromUser\",\n    \"imageUrl\" : \"https://profile.example.com/from-user\"\n  },\n  \"toUser\" : {\n    \"id\" : \"07cd71c0-93d0-4531-941f-58f95697bc0d\",\n    \"name\" : \"ToUser\",\n    \"email\" : \"test@jmt-monster.com\",\n    \"nickname\" : \"ToUser\",\n    \"imageUrl\" : \"https://profile.example.com/to-user\"\n  }\n}"
                   }
                 }
               }
@@ -362,7 +396,7 @@
           "schema" : {
             "type" : "string"
           },
-          "example" : "Bearer 382680c1-abef-4310-b65c-a1765ef9f862"
+          "example" : "Bearer 5e07c712-5732-4877-bd02-2433c46db139"
         } ],
         "responses" : {
           "200" : {
@@ -374,7 +408,7 @@
                 },
                 "examples" : {
                   "my-user" : {
-                    "value" : "{\n  \"isSuccess\" : true,\n  \"user\" : {\n    \"id\" : \"242180ef-601d-4f3e-89b2-c40aa313e232\",\n    \"name\" : \"이지호\",\n    \"email\" : \"optional.int@kakao.com\",\n    \"nickname\" : null,\n    \"address\" : null,\n    \"imageUrl\" : null,\n    \"emailVerified\" : false,\n    \"extraInfoInjected\" : false,\n    \"verified\" : false\n  }\n}"
+                    "value" : "{\n  \"isSuccess\" : true,\n  \"user\" : {\n    \"id\" : \"5bb606ec-1ebb-49f6-b746-7729167f2aea\",\n    \"name\" : \"이지호\",\n    \"email\" : \"optional.int@kakao.com\",\n    \"nickname\" : null,\n    \"address\" : null,\n    \"imageUrl\" : null,\n    \"emailVerified\" : false,\n    \"extraInfoInjected\" : false,\n    \"verified\" : false\n  }\n}"
                   }
                 }
               }
@@ -397,7 +431,7 @@
           "schema" : {
             "type" : "string"
           },
-          "example" : "Bearer c7cad56e-598b-4a70-afe1-59dc4c4336dc"
+          "example" : "Bearer d5872927-46bc-4701-a19d-8e5a1c491fc0"
         } ],
         "requestBody" : {
           "content" : {
@@ -423,7 +457,7 @@
                 },
                 "examples" : {
                   "submit-extra-info" : {
-                    "value" : "{\n  \"isSuccess\" : true,\n  \"user\" : {\n    \"id\" : \"cdb8c1dd-7d80-4b63-a284-940355048af5\",\n    \"name\" : \"이지호\",\n    \"email\" : \"optional.int@kakao.com\",\n    \"nickname\" : \"DPS0340\",\n    \"address\" : \"경기도 시흥시 서울대학로278번길 19-13\",\n    \"imageUrl\" : null,\n    \"emailVerified\" : false,\n    \"extraInfoInjected\" : true,\n    \"verified\" : false\n  }\n}"
+                    "value" : "{\n  \"isSuccess\" : true,\n  \"user\" : {\n    \"id\" : \"94c87a88-b5c6-408b-b53e-94699455ccbb\",\n    \"name\" : \"이지호\",\n    \"email\" : \"optional.int@kakao.com\",\n    \"nickname\" : \"DPS0340\",\n    \"address\" : \"경기도 시흥시 서울대학로278번길 19-13\",\n    \"imageUrl\" : null,\n    \"emailVerified\" : false,\n    \"extraInfoInjected\" : true,\n    \"verified\" : false\n  }\n}"
                   }
                 }
               }
@@ -435,25 +469,7 @@
   },
   "components" : {
     "schemas" : {
-      "api-v1-images-1687754793" : {
-        "type" : "object",
-        "properties" : {
-          "filename" : {
-            "type" : "string",
-            "description" : "File name of image in S3"
-          }
-        }
-      },
-      "api-v1-images894266175" : {
-        "type" : "object",
-        "properties" : {
-          "url" : {
-            "type" : "string",
-            "description" : "URL of image in S3"
-          }
-        }
-      },
-      "api-v1-friend-requests-id529653109" : {
+      "api-v1-friend-requests529653109" : {
         "type" : "object",
         "properties" : {
           "toUser" : {
@@ -513,32 +529,6 @@
           "status" : {
             "type" : "string",
             "description" : "상태"
-          }
-        }
-      },
-      "api-v1-hello527089244" : {
-        "type" : "object",
-        "properties" : {
-          "success" : {
-            "type" : "boolean",
-            "description" : "성공 여부를 나타내는 불린 변수"
-          },
-          "createdOn" : {
-            "type" : "string",
-            "description" : "객체 생성 시각"
-          },
-          "value" : {
-            "type" : "string",
-            "description" : "리스폰스 메시지"
-          }
-        }
-      },
-      "api-v1-friend-requests-id-989932600" : {
-        "type" : "object",
-        "properties" : {
-          "status" : {
-            "type" : "string",
-            "description" : "친구 요청 상태 (ACCEPTED)"
           }
         }
       },
@@ -614,6 +604,39 @@
           }
         }
       },
+      "api-v1-users701179906" : {
+        "type" : "object",
+        "properties" : {
+          "content" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "imageUrl" : {
+                  "type" : "string",
+                  "description" : "사용자 프로필 사진 주소"
+                },
+                "nickname" : {
+                  "type" : "string",
+                  "description" : "사용자 닉네임"
+                },
+                "name" : {
+                  "type" : "string",
+                  "description" : "사용자 이름"
+                },
+                "id" : {
+                  "type" : "string",
+                  "description" : "사용자 ID"
+                },
+                "email" : {
+                  "type" : "string",
+                  "description" : "사용자 이메일"
+                }
+              }
+            }
+          }
+        }
+      },
       "users-me-extra-info-1863268708" : {
         "type" : "object",
         "properties" : {
@@ -661,6 +684,50 @@
           "isSuccess" : {
             "type" : "boolean",
             "description" : "성공 여부"
+          }
+        }
+      },
+      "api-v1-images-1687754793" : {
+        "type" : "object",
+        "properties" : {
+          "filename" : {
+            "type" : "string",
+            "description" : "File name of image in S3"
+          }
+        }
+      },
+      "api-v1-images894266175" : {
+        "type" : "object",
+        "properties" : {
+          "url" : {
+            "type" : "string",
+            "description" : "URL of image in S3"
+          }
+        }
+      },
+      "api-v1-hello527089244" : {
+        "type" : "object",
+        "properties" : {
+          "success" : {
+            "type" : "boolean",
+            "description" : "성공 여부를 나타내는 불린 변수"
+          },
+          "createdOn" : {
+            "type" : "string",
+            "description" : "객체 생성 시각"
+          },
+          "value" : {
+            "type" : "string",
+            "description" : "리스폰스 메시지"
+          }
+        }
+      },
+      "api-v1-friend-requests-id-989932600" : {
+        "type" : "object",
+        "properties" : {
+          "status" : {
+            "type" : "string",
+            "description" : "친구 요청 상태 (ACCEPTED)"
           }
         }
       },

--- a/src/main/resources/static/docs/openapi3.json
+++ b/src/main/resources/static/docs/openapi3.json
@@ -28,7 +28,7 @@
                 },
                 "examples" : {
                   "friend-request-get-list" : {
-                    "value" : "{\n  \"content\" : [ {\n    \"id\" : \"382d4131-d0c5-41b9-9271-5c26dd5337ee\",\n    \"fromUser\" : {\n      \"id\" : \"2ee76b23-d47a-4e9e-a4bb-062f99c541cc\",\n      \"name\" : \"FromUser\",\n      \"email\" : \"test@jmt-monster.com\",\n      \"nickname\" : \"FromUser\",\n      \"imageUrl\" : \"https://profile.example.com/from-user\"\n    },\n    \"toUser\" : {\n      \"id\" : \"558622ea-063a-42d4-adbc-3a2822651b06\",\n      \"name\" : \"ToUser\",\n      \"email\" : \"test@jmt-monster.com\",\n      \"nickname\" : \"ToUser\",\n      \"imageUrl\" : \"https://profile.example.com/to-user\"\n    },\n    \"status\" : \"PENDING\"\n  } ],\n  \"pageable\" : {\n    \"sort\" : {\n      \"empty\" : true,\n      \"sorted\" : false,\n      \"unsorted\" : true\n    },\n    \"offset\" : 0,\n    \"pageNumber\" : 0,\n    \"pageSize\" : 10,\n    \"paged\" : true,\n    \"unpaged\" : false\n  },\n  \"totalPages\" : 1,\n  \"totalElements\" : 1,\n  \"last\" : true,\n  \"size\" : 10,\n  \"sort\" : {\n    \"empty\" : true,\n    \"sorted\" : false,\n    \"unsorted\" : true\n  },\n  \"number\" : 0,\n  \"numberOfElements\" : 1,\n  \"first\" : true,\n  \"empty\" : false\n}"
+                    "value" : "{\n  \"content\" : [ {\n    \"id\" : \"7557f369-2687-4c7a-8604-17d9d7129871\",\n    \"fromUser\" : {\n      \"id\" : \"e5054725-7407-479e-ba8e-ba07d33c44c0\",\n      \"name\" : \"FromUser\",\n      \"email\" : \"test@jmt-monster.com\",\n      \"nickname\" : \"FromUser\",\n      \"imageUrl\" : \"https://profile.example.com/from-user\"\n    },\n    \"toUser\" : {\n      \"id\" : \"723eaf6d-9d27-4ef0-81ec-ca4f79555c42\",\n      \"name\" : \"ToUser\",\n      \"email\" : \"test@jmt-monster.com\",\n      \"nickname\" : \"ToUser\",\n      \"imageUrl\" : \"https://profile.example.com/to-user\"\n    },\n    \"status\" : \"PENDING\"\n  } ],\n  \"pageable\" : {\n    \"sort\" : {\n      \"empty\" : true,\n      \"sorted\" : false,\n      \"unsorted\" : true\n    },\n    \"offset\" : 0,\n    \"pageNumber\" : 0,\n    \"pageSize\" : 10,\n    \"paged\" : true,\n    \"unpaged\" : false\n  },\n  \"totalPages\" : 1,\n  \"totalElements\" : 1,\n  \"last\" : true,\n  \"number\" : 0,\n  \"sort\" : {\n    \"empty\" : true,\n    \"sorted\" : false,\n    \"unsorted\" : true\n  },\n  \"size\" : 10,\n  \"numberOfElements\" : 1,\n  \"first\" : true,\n  \"empty\" : false\n}"
                   }
                 }
               }
@@ -49,7 +49,7 @@
               },
               "examples" : {
                 "friend-request-create" : {
-                  "value" : "{\n  \"fromUserId\" : \"d811543c-24de-4126-9782-c4b3502f09f4\",\n  \"toUserId\" : \"9e96bb81-e7c4-4615-b94c-a12eaeaa003a\"\n}"
+                  "value" : "{\n  \"fromUserId\" : \"72cd3e27-b121-4549-9ded-180cc6382325\",\n  \"toUserId\" : \"ef93e695-e42e-4cd8-ab52-53a3ef5e5d63\"\n}"
                 }
               }
             }
@@ -61,11 +61,11 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/api-v1-friend-requests529653109"
+                  "$ref" : "#/components/schemas/api-v1-friend-requests-id529653109"
                 },
                 "examples" : {
                   "friend-request-create" : {
-                    "value" : "{\n  \"id\" : \"34714d12-3152-4409-9080-05e83050a0cb\",\n  \"fromUser\" : {\n    \"id\" : \"d811543c-24de-4126-9782-c4b3502f09f4\",\n    \"name\" : \"FromUser\",\n    \"email\" : \"test@jmt-monster.com\",\n    \"nickname\" : \"FromUser\",\n    \"imageUrl\" : \"https://profile.example.com/from-user\"\n  },\n  \"toUser\" : {\n    \"id\" : \"9e96bb81-e7c4-4615-b94c-a12eaeaa003a\",\n    \"name\" : \"ToUser\",\n    \"email\" : \"test@jmt-monster.com\",\n    \"nickname\" : \"ToUser\",\n    \"imageUrl\" : \"https://profile.example.com/to-user\"\n  },\n  \"status\" : \"PENDING\",\n  \"_links\" : {\n    \"list\" : {\n      \"href\" : \"http://localhost:8080/api/v1/friend-requests\"\n    },\n    \"self\" : {\n      \"href\" : \"http://localhost:8080/api/v1/friend-requests/34714d12-3152-4409-9080-05e83050a0cb\"\n    },\n    \"update\" : {\n      \"href\" : \"http://localhost:8080/api/v1/friend-requests/34714d12-3152-4409-9080-05e83050a0cb\"\n    },\n    \"delete\" : {\n      \"href\" : \"http://localhost:8080/api/v1/friend-requests/34714d12-3152-4409-9080-05e83050a0cb\"\n    }\n  }\n}"
+                    "value" : "{\n  \"id\" : \"0b0ad693-3d4f-4268-ab8c-1a9d90443e61\",\n  \"fromUser\" : {\n    \"id\" : \"72cd3e27-b121-4549-9ded-180cc6382325\",\n    \"name\" : \"FromUser\",\n    \"email\" : \"test@jmt-monster.com\",\n    \"nickname\" : \"FromUser\",\n    \"imageUrl\" : \"https://profile.example.com/from-user\"\n  },\n  \"toUser\" : {\n    \"id\" : \"ef93e695-e42e-4cd8-ab52-53a3ef5e5d63\",\n    \"name\" : \"ToUser\",\n    \"email\" : \"test@jmt-monster.com\",\n    \"nickname\" : \"ToUser\",\n    \"imageUrl\" : \"https://profile.example.com/to-user\"\n  },\n  \"status\" : \"PENDING\",\n  \"_links\" : {\n    \"list\" : {\n      \"href\" : \"http://localhost:8080/api/v1/friend-requests\"\n    },\n    \"self\" : {\n      \"href\" : \"http://localhost:8080/api/v1/friend-requests/0b0ad693-3d4f-4268-ab8c-1a9d90443e61\"\n    },\n    \"update\" : {\n      \"href\" : \"http://localhost:8080/api/v1/friend-requests/0b0ad693-3d4f-4268-ab8c-1a9d90443e61\"\n    },\n    \"delete\" : {\n      \"href\" : \"http://localhost:8080/api/v1/friend-requests/0b0ad693-3d4f-4268-ab8c-1a9d90443e61\"\n    }\n  }\n}"
                   }
                 }
               }
@@ -115,7 +115,7 @@
                 },
                 "examples" : {
                   "friend-get-list" : {
-                    "value" : "{\n  \"content\" : [ {\n    \"id\" : \"15a0254a-28bf-45f9-bb73-236be0d492c5\",\n    \"fromUser\" : {\n      \"id\" : \"28a343b5-8f58-4486-9794-22cab3f933a9\",\n      \"name\" : \"FromUser\",\n      \"email\" : \"test@jmt-monster.com\",\n      \"nickname\" : \"FromUser\",\n      \"imageUrl\" : \"https://profile.example.com/from-user\"\n    },\n    \"toUser\" : {\n      \"id\" : \"b324f643-36be-4196-a799-1b4663d431bf\",\n      \"name\" : \"ToUser\",\n      \"email\" : \"test@jmt-monster.com\",\n      \"nickname\" : \"ToUser\",\n      \"imageUrl\" : \"https://profile.example.com/to-user\"\n    }\n  } ],\n  \"pageable\" : {\n    \"sort\" : {\n      \"empty\" : true,\n      \"sorted\" : false,\n      \"unsorted\" : true\n    },\n    \"offset\" : 0,\n    \"pageNumber\" : 0,\n    \"pageSize\" : 10,\n    \"paged\" : true,\n    \"unpaged\" : false\n  },\n  \"totalPages\" : 1,\n  \"totalElements\" : 1,\n  \"last\" : true,\n  \"size\" : 10,\n  \"sort\" : {\n    \"empty\" : true,\n    \"sorted\" : false,\n    \"unsorted\" : true\n  },\n  \"number\" : 0,\n  \"numberOfElements\" : 1,\n  \"first\" : true,\n  \"empty\" : false\n}"
+                    "value" : "{\n  \"content\" : [ {\n    \"id\" : \"573cdb25-7d7f-44d6-8a10-ecf5442c7909\",\n    \"fromUser\" : {\n      \"id\" : \"de7d6709-4cfc-4318-ab9b-75c032a4ffb5\",\n      \"name\" : \"FromUser\",\n      \"email\" : \"test@jmt-monster.com\",\n      \"nickname\" : \"FromUser\",\n      \"imageUrl\" : \"https://profile.example.com/from-user\"\n    },\n    \"toUser\" : {\n      \"id\" : \"3c3bf60d-73a7-469c-9ce9-cbe6aa30c457\",\n      \"name\" : \"ToUser\",\n      \"email\" : \"test@jmt-monster.com\",\n      \"nickname\" : \"ToUser\",\n      \"imageUrl\" : \"https://profile.example.com/to-user\"\n    }\n  } ],\n  \"pageable\" : {\n    \"sort\" : {\n      \"empty\" : true,\n      \"sorted\" : false,\n      \"unsorted\" : true\n    },\n    \"offset\" : 0,\n    \"pageNumber\" : 0,\n    \"pageSize\" : 10,\n    \"paged\" : true,\n    \"unpaged\" : false\n  },\n  \"totalPages\" : 1,\n  \"totalElements\" : 1,\n  \"last\" : true,\n  \"number\" : 0,\n  \"sort\" : {\n    \"empty\" : true,\n    \"sorted\" : false,\n    \"unsorted\" : true\n  },\n  \"size\" : 10,\n  \"numberOfElements\" : 1,\n  \"first\" : true,\n  \"empty\" : false\n}"
                   }
                 }
               }
@@ -140,7 +140,7 @@
                 },
                 "examples" : {
                   "hello-get" : {
-                    "value" : "{\n  \"value\" : \"hello\",\n  \"success\" : true,\n  \"createdOn\" : \"2022-07-09T12:03:23.996112\"\n}"
+                    "value" : "{\n  \"value\" : \"hello\",\n  \"success\" : true,\n  \"createdOn\" : \"2022-07-09T12:09:04.506379\"\n}"
                   }
                 }
               }
@@ -177,7 +177,7 @@
                 },
                 "examples" : {
                   "hello-create" : {
-                    "value" : "{\n  \"value\" : \"hello example1\",\n  \"success\" : true,\n  \"createdOn\" : \"2022-07-09T12:03:23.92818\"\n}"
+                    "value" : "{\n  \"value\" : \"hello example1\",\n  \"success\" : true,\n  \"createdOn\" : \"2022-07-09T12:09:04.464899\"\n}"
                   }
                 }
               }
@@ -259,7 +259,7 @@
                 },
                 "examples" : {
                   "user-profile-search" : {
-                    "value" : "{\n  \"content\" : [ {\n    \"id\" : \"44b31a0f-a1f3-4b27-b684-d011ec2bb462\",\n    \"name\" : \"Testuser\",\n    \"email\" : \"testuser@example.com\",\n    \"nickname\" : \"Testuser\",\n    \"imageUrl\" : \"https://profile.example.com/testuser\"\n  } ],\n  \"pageable\" : {\n    \"sort\" : {\n      \"empty\" : true,\n      \"sorted\" : false,\n      \"unsorted\" : true\n    },\n    \"offset\" : 0,\n    \"pageNumber\" : 0,\n    \"pageSize\" : 10,\n    \"paged\" : true,\n    \"unpaged\" : false\n  },\n  \"totalPages\" : 1,\n  \"totalElements\" : 1,\n  \"last\" : true,\n  \"size\" : 10,\n  \"sort\" : {\n    \"empty\" : true,\n    \"sorted\" : false,\n    \"unsorted\" : true\n  },\n  \"number\" : 0,\n  \"numberOfElements\" : 1,\n  \"first\" : true,\n  \"empty\" : false\n}"
+                    "value" : "{\n  \"content\" : [ {\n    \"id\" : \"dd4354c2-b020-4814-9966-1807d0aea4ad\",\n    \"name\" : \"Testuser\",\n    \"email\" : \"testuser@example.com\",\n    \"nickname\" : \"Testuser\",\n    \"imageUrl\" : \"https://profile.example.com/testuser\"\n  } ],\n  \"pageable\" : {\n    \"sort\" : {\n      \"empty\" : true,\n      \"sorted\" : false,\n      \"unsorted\" : true\n    },\n    \"offset\" : 0,\n    \"pageNumber\" : 0,\n    \"pageSize\" : 10,\n    \"paged\" : true,\n    \"unpaged\" : false\n  },\n  \"totalPages\" : 1,\n  \"totalElements\" : 1,\n  \"last\" : true,\n  \"number\" : 0,\n  \"sort\" : {\n    \"empty\" : true,\n    \"sorted\" : false,\n    \"unsorted\" : true\n  },\n  \"size\" : 10,\n  \"numberOfElements\" : 1,\n  \"first\" : true,\n  \"empty\" : false\n}"
                   }
                 }
               }
@@ -289,11 +289,11 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/api-v1-friend-requests529653109"
+                  "$ref" : "#/components/schemas/api-v1-friend-requests-id529653109"
                 },
                 "examples" : {
                   "friend-request-get-one" : {
-                    "value" : "{\n  \"id\" : \"73aeb8be-cbd7-4b18-89bd-2f81f6244a37\",\n  \"fromUser\" : {\n    \"id\" : \"f0fac66d-5a9a-443d-95a4-5848bbbcd014\",\n    \"name\" : \"FromUser\",\n    \"email\" : \"test@jmt-monster.com\",\n    \"nickname\" : \"FromUser\",\n    \"imageUrl\" : \"https://profile.example.com/from-user\"\n  },\n  \"toUser\" : {\n    \"id\" : \"749caa7a-8fab-4e1e-a721-cc37f57ba004\",\n    \"name\" : \"ToUser\",\n    \"email\" : \"test@jmt-monster.com\",\n    \"nickname\" : \"ToUser\",\n    \"imageUrl\" : \"https://profile.example.com/to-user\"\n  },\n  \"status\" : \"PENDING\"\n}"
+                    "value" : "{\n  \"id\" : \"f08c6fa9-09c9-4223-aeb9-88f6fc9a1f00\",\n  \"fromUser\" : {\n    \"id\" : \"423de3cc-99a7-465b-b847-fd6d2ecda56e\",\n    \"name\" : \"FromUser\",\n    \"email\" : \"test@jmt-monster.com\",\n    \"nickname\" : \"FromUser\",\n    \"imageUrl\" : \"https://profile.example.com/from-user\"\n  },\n  \"toUser\" : {\n    \"id\" : \"bdb291bf-44c8-4e00-b335-e5ebd11c4d04\",\n    \"name\" : \"ToUser\",\n    \"email\" : \"test@jmt-monster.com\",\n    \"nickname\" : \"ToUser\",\n    \"imageUrl\" : \"https://profile.example.com/to-user\"\n  },\n  \"status\" : \"PENDING\"\n}"
                   }
                 }
               }
@@ -335,11 +335,11 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/api-v1-friend-requests529653109"
+                  "$ref" : "#/components/schemas/api-v1-friend-requests-id529653109"
                 },
                 "examples" : {
                   "friend-request-update-to-create-friend" : {
-                    "value" : "{\n  \"id\" : \"a0b8da52-2f03-4ecb-9c1e-9e68bc5312fd\",\n  \"fromUser\" : {\n    \"id\" : \"c2d9e008-41ca-45df-9071-1c4a3de81389\",\n    \"name\" : \"FromUser\",\n    \"email\" : \"test@jmt-monster.com\",\n    \"nickname\" : \"FromUser\",\n    \"imageUrl\" : \"https://profile.example.com/from-user\"\n  },\n  \"toUser\" : {\n    \"id\" : \"e0b5f24b-ddad-4a70-8529-c97612f52763\",\n    \"name\" : \"ToUser\",\n    \"email\" : \"test@jmt-monster.com\",\n    \"nickname\" : \"ToUser\",\n    \"imageUrl\" : \"https://profile.example.com/to-user\"\n  },\n  \"status\" : \"ACCEPTED\"\n}"
+                    "value" : "{\n  \"id\" : \"0f00714c-0c8c-4cf4-a192-fc4cce92e163\",\n  \"fromUser\" : {\n    \"id\" : \"beaa9244-7a1c-41c7-923c-1d45f74732e2\",\n    \"name\" : \"FromUser\",\n    \"email\" : \"test@jmt-monster.com\",\n    \"nickname\" : \"FromUser\",\n    \"imageUrl\" : \"https://profile.example.com/from-user\"\n  },\n  \"toUser\" : {\n    \"id\" : \"8f4a28af-7db6-49e7-bb1d-04eaa4c65b21\",\n    \"name\" : \"ToUser\",\n    \"email\" : \"test@jmt-monster.com\",\n    \"nickname\" : \"ToUser\",\n    \"imageUrl\" : \"https://profile.example.com/to-user\"\n  },\n  \"status\" : \"ACCEPTED\"\n}"
                   }
                 }
               }
@@ -373,7 +373,7 @@
                 },
                 "examples" : {
                   "friend-get-one" : {
-                    "value" : "{\n  \"id\" : \"d45533bc-75e3-4054-a88c-41ef30e03a2f\",\n  \"fromUser\" : {\n    \"id\" : \"92a4051b-66e2-48ad-90f7-6f0f9625aece\",\n    \"name\" : \"FromUser\",\n    \"email\" : \"test@jmt-monster.com\",\n    \"nickname\" : \"FromUser\",\n    \"imageUrl\" : \"https://profile.example.com/from-user\"\n  },\n  \"toUser\" : {\n    \"id\" : \"07cd71c0-93d0-4531-941f-58f95697bc0d\",\n    \"name\" : \"ToUser\",\n    \"email\" : \"test@jmt-monster.com\",\n    \"nickname\" : \"ToUser\",\n    \"imageUrl\" : \"https://profile.example.com/to-user\"\n  }\n}"
+                    "value" : "{\n  \"id\" : \"43f823e3-d470-4e92-81de-61412215ea6c\",\n  \"fromUser\" : {\n    \"id\" : \"b6d43ddb-c0e3-435f-9fe6-573c47abb56a\",\n    \"name\" : \"FromUser\",\n    \"email\" : \"test@jmt-monster.com\",\n    \"nickname\" : \"FromUser\",\n    \"imageUrl\" : \"https://profile.example.com/from-user\"\n  },\n  \"toUser\" : {\n    \"id\" : \"4027b995-9243-4de6-84b4-56bdfb1a36e4\",\n    \"name\" : \"ToUser\",\n    \"email\" : \"test@jmt-monster.com\",\n    \"nickname\" : \"ToUser\",\n    \"imageUrl\" : \"https://profile.example.com/to-user\"\n  }\n}"
                   }
                 }
               }
@@ -396,7 +396,7 @@
           "schema" : {
             "type" : "string"
           },
-          "example" : "Bearer 5e07c712-5732-4877-bd02-2433c46db139"
+          "example" : "Bearer e12e12c1-7bb1-4b10-91d0-66fe266db2c8"
         } ],
         "responses" : {
           "200" : {
@@ -408,7 +408,7 @@
                 },
                 "examples" : {
                   "my-user" : {
-                    "value" : "{\n  \"isSuccess\" : true,\n  \"user\" : {\n    \"id\" : \"5bb606ec-1ebb-49f6-b746-7729167f2aea\",\n    \"name\" : \"이지호\",\n    \"email\" : \"optional.int@kakao.com\",\n    \"nickname\" : null,\n    \"address\" : null,\n    \"imageUrl\" : null,\n    \"emailVerified\" : false,\n    \"extraInfoInjected\" : false,\n    \"verified\" : false\n  }\n}"
+                    "value" : "{\n  \"isSuccess\" : true,\n  \"user\" : {\n    \"id\" : \"494c9bbd-3bdc-424a-ba6a-f4d2dae6cdd8\",\n    \"name\" : \"이지호\",\n    \"email\" : \"optional.int@kakao.com\",\n    \"nickname\" : null,\n    \"address\" : null,\n    \"imageUrl\" : null,\n    \"emailVerified\" : false,\n    \"extraInfoInjected\" : false,\n    \"verified\" : false\n  }\n}"
                   }
                 }
               }
@@ -431,7 +431,7 @@
           "schema" : {
             "type" : "string"
           },
-          "example" : "Bearer d5872927-46bc-4701-a19d-8e5a1c491fc0"
+          "example" : "Bearer db9d628a-d3cd-4a1a-abdd-88ae18c634fa"
         } ],
         "requestBody" : {
           "content" : {
@@ -457,7 +457,7 @@
                 },
                 "examples" : {
                   "submit-extra-info" : {
-                    "value" : "{\n  \"isSuccess\" : true,\n  \"user\" : {\n    \"id\" : \"94c87a88-b5c6-408b-b53e-94699455ccbb\",\n    \"name\" : \"이지호\",\n    \"email\" : \"optional.int@kakao.com\",\n    \"nickname\" : \"DPS0340\",\n    \"address\" : \"경기도 시흥시 서울대학로278번길 19-13\",\n    \"imageUrl\" : null,\n    \"emailVerified\" : false,\n    \"extraInfoInjected\" : true,\n    \"verified\" : false\n  }\n}"
+                    "value" : "{\n  \"isSuccess\" : true,\n  \"user\" : {\n    \"id\" : \"0f543b07-4165-43d8-b42d-cc4ee6a38e6a\",\n    \"name\" : \"이지호\",\n    \"email\" : \"optional.int@kakao.com\",\n    \"nickname\" : \"DPS0340\",\n    \"address\" : \"경기도 시흥시 서울대학로278번길 19-13\",\n    \"imageUrl\" : null,\n    \"emailVerified\" : false,\n    \"extraInfoInjected\" : true,\n    \"verified\" : false\n  }\n}"
                   }
                 }
               }
@@ -469,7 +469,7 @@
   },
   "components" : {
     "schemas" : {
-      "api-v1-friend-requests529653109" : {
+      "api-v1-friend-requests-id529653109" : {
         "type" : "object",
         "properties" : {
           "toUser" : {
@@ -705,6 +705,15 @@
           }
         }
       },
+      "api-v1-friend-requests-id-989932600" : {
+        "type" : "object",
+        "properties" : {
+          "status" : {
+            "type" : "string",
+            "description" : "친구 요청 상태 (ACCEPTED)"
+          }
+        }
+      },
       "api-v1-hello527089244" : {
         "type" : "object",
         "properties" : {
@@ -719,15 +728,6 @@
           "value" : {
             "type" : "string",
             "description" : "리스폰스 메시지"
-          }
-        }
-      },
-      "api-v1-friend-requests-id-989932600" : {
-        "type" : "object",
-        "properties" : {
-          "status" : {
-            "type" : "string",
-            "description" : "친구 요청 상태 (ACCEPTED)"
           }
         }
       },

--- a/src/test/java/com/techeer/f5/jmtmonster/domain/user/controller/UserProfileControllerTest.java
+++ b/src/test/java/com/techeer/f5/jmtmonster/domain/user/controller/UserProfileControllerTest.java
@@ -1,0 +1,140 @@
+package com.techeer.f5.jmtmonster.domain.user.controller;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static com.techeer.f5.jmtmonster.document.util.ResponseFieldDescriptorUtils.withPageDescriptorsIgnored;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.SimpleType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.techeer.f5.jmtmonster.domain.user.domain.User;
+import com.techeer.f5.jmtmonster.domain.user.dto.BasicUserResponseDto;
+import com.techeer.f5.jmtmonster.domain.user.dto.UserMapper;
+import com.techeer.f5.jmtmonster.domain.user.service.UserService;
+import com.techeer.f5.jmtmonster.util.FieldUtil;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@WebMvcTest(UserProfileController.class)
+@ExtendWith(SpringExtension.class)
+@AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureRestDocs
+@ActiveProfiles(profiles = {"secret", "test", "disable-auth"})
+@Import({UserMapper.class})
+@DisplayName("사용자 프로필 API")
+class UserProfileControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserMapper userMapper;
+
+    @MockBean
+    private UserService userService;
+
+    @Nested
+    @DisplayName("사용자 프로필 조회")
+    class GetUserProfileTest {
+
+        @Test
+        @DisplayName("성공")
+        void get_ok() throws Exception {
+            User user = User.builder()
+                    .name("Testuser")
+                    .email("testuser@example.com")
+                    .nickname("Testuser")
+                    .imageUrl("https://profile.example.com/testuser")
+                    .build();
+
+            FieldUtil.writeField(user, "id", UUID.randomUUID());
+
+            List<User> content = List.of(user);
+
+            Page<User> pageResponse = new PageImpl<>(content, PageRequest.of(0, 10),
+                    content.size());
+
+            Page<BasicUserResponseDto> response = pageResponse.map(
+                    userMapper::toBasicUserResponseDto);
+
+            given(userService.searchByEmail(
+                    any(),
+                    eq(user.getEmail())
+            )).willReturn(pageResponse);
+
+            FieldDescriptor[] responseFieldDescriptors = {
+                    fieldWithPath("content.[].id")
+                            .type(JsonFieldType.STRING)
+                            .description("사용자 ID"),
+                    fieldWithPath("content.[].name")
+                            .type(JsonFieldType.STRING)
+                            .description("사용자 이름"),
+                    fieldWithPath("content.[].email")
+                            .type(JsonFieldType.STRING)
+                            .description("사용자 이메일"),
+                    fieldWithPath("content.[].nickname")
+                            .type(JsonFieldType.STRING)
+                            .description("사용자 닉네임"),
+                    fieldWithPath("content.[].imageUrl")
+                            .type(JsonFieldType.STRING)
+                            .description("사용자 프로필 사진 주소")};
+
+            mockMvc.perform(get("/api/v1/users")
+                            .queryParam("email", user.getEmail())
+                            .accept(MediaType.APPLICATION_JSON)
+                            .header("Origin", "*"))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(MockMvcResultMatchers.content()
+                            .string(objectMapper.writeValueAsString(response)))
+                    .andDo(document("user-profile-search",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            resource(ResourceSnippetParameters.builder()
+                                    .description("사용자 프로필을 이메일로 조회합니다.")
+                                    .summary("사용자 프로필 조회")
+                                    .requestParameters(
+                                            parameterWithName("email")
+                                                    .type(SimpleType.STRING)
+                                                    .description("사용자 이메일")
+                                                    .optional())
+                                    .responseFields(
+                                            withPageDescriptorsIgnored(responseFieldDescriptors))
+                                    .build())));
+        }
+    }
+}


### PR DESCRIPTION
## ABOUT

친구 추가를 하기 위해서는 사용자 ID가 필요하고, 사용자 입장에서 사용자 검색을 하기 위해 사용자 이메일을 이용한 ID 조회가 필요합니다.

따라서 사용자 프로필 API를 추가합니다.

## DONE

- 사용자 프로필 API 추가, 테스트, 문서화 완료
- 친구 및 친구 요청 목록 조회 API 미흡점 보완 (`totalElements`가 이상하게 나오던 문제 해결)
  - 쿼리에 `offset`, `limit` 추가
  - 카운트 쿼리에 join 추가
- `openapi3.json` 업데이트