### PR TITLE
User 엔티티 내 주소 관련 컬럼 제거

### DIFF
--- a/src/main/java/com/techeer/f5/jmtmonster/domain/home/repository/HomeQueryRepositoryImpl.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/home/repository/HomeQueryRepositoryImpl.java
@@ -91,8 +91,6 @@ public class HomeQueryRepositoryImpl implements HomeQueryRepository {
                     .build();
         }
 
-        user.setAddress(home.getName());
-
         homeToUser.setCurrent(true);
 
         homeToUserRepository.saveAndFlush(homeToUser);

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/user/domain/User.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/user/domain/User.java
@@ -53,12 +53,6 @@ public class User {
     @Setter
     private String nickname = null;
 
-    @Size(min = 1, max = 1024, message = "주소 길이는 1자부터 1024자까지 가능합니다.")
-    @Nullable
-    @Builder.Default
-    @Setter
-    private String address = null;
-
     @Size(min = 1, max = 4096, message = "이미지 주소 길이는 1자부터 1024자까지 가능합니다.")
     @Nullable
     @Builder.Default
@@ -95,10 +89,9 @@ public class User {
         tokens.add(persistentToken);
     }
 
-    public boolean addExtraInfo(String nickname, String address, String imageUrl)
+    public boolean addExtraInfo(String nickname, String imageUrl)
             throws IllegalStateException {
         this.nickname = nickname;
-        this.address = address;
         this.imageUrl = imageUrl;
 
         extraInfoInjected = true;

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/user/dto/UserMapper.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/user/dto/UserMapper.java
@@ -22,7 +22,6 @@ public class UserMapper {
                 .name(entity.getName())
                 .email(entity.getEmail())
                 .nickname(entity.getNickname())
-                .address(entity.getAddress())
                 .imageUrl(entity.getImageUrl())
                 .emailVerified(entity.getEmailVerified())
                 .extraInfoInjected(entity.getExtraInfoInjected())

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/user/service/UserService.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/user/service/UserService.java
@@ -93,7 +93,6 @@ public class UserService {
 
         user.addExtraInfo(
                 extraUserInfoRequestDto.getNickname(),
-                extraUserInfoRequestDto.getAddress(),
                 extraUserInfoRequestDto.getImageUrl());
 
         user = userRepository.saveAndFlush(user);

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/user/service/UserService.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/user/service/UserService.java
@@ -97,8 +97,6 @@ public class UserService {
 
         user = userRepository.saveAndFlush(user);
 
-        // TODO: migrate API using extraUserInfoRequestDto.getAddressCode()
-
         return userMapper.toUserResponseDto(user);
     }
 }

--- a/src/test/java/com/techeer/f5/jmtmonster/domain/home/repository/HomeRepositoryTest.java
+++ b/src/test/java/com/techeer/f5/jmtmonster/domain/home/repository/HomeRepositoryTest.java
@@ -73,11 +73,11 @@ public class HomeRepositoryTest {
                 .name("이지호")
                 .nickname("DPS0340")
                 .email("optional.int@kakao.com")
-                .address("서울대학로27번길 19-13")
                 .emailVerified(true)
                 .extraInfoInjected(true)
                 .verified(true)
                 .build();
+
 
         user = userRepository.saveAndFlush(user);
 
@@ -185,8 +185,6 @@ public class HomeRepositoryTest {
 
         // when
         homeRepository.migrate(user, newHome);
-
-        assertEquals(user.getAddress(), newHome.getName());
 
         List<HomeToUser> foundHomeToUsers = homeRepository.findAllHomeToUsersByUser(user);
 

--- a/src/test/java/com/techeer/f5/jmtmonster/domain/home/service/HomeServiceTest.java
+++ b/src/test/java/com/techeer/f5/jmtmonster/domain/home/service/HomeServiceTest.java
@@ -59,7 +59,6 @@ public class HomeServiceTest {
                 .name("이지호")
                 .nickname("DPS0340")
                 .email("optional.int@kakao.com")
-                .address("서울대학로27번길 19-13")
                 .emailVerified(true)
                 .extraInfoInjected(true)
                 .verified(true)

--- a/src/test/java/com/techeer/f5/jmtmonster/domain/user/UserControllerTest.java
+++ b/src/test/java/com/techeer/f5/jmtmonster/domain/user/UserControllerTest.java
@@ -218,7 +218,6 @@ public class UserControllerTest {
         assertThat(user.getName()).isEqualTo(userResponseDto.getUser().getName());
         assertThat(user.getEmail()).isEqualTo(userResponseDto.getUser().getEmail());
         assertThat(userResponseDto.getUser().getNickname()).isEqualTo("DPS0340");
-        assertThat(userResponseDto.getUser().getAddress()).isEqualTo("경기도 시흥시 서울대학로278번길 19-13");
         assertThat(userResponseDto.getUser().getImageUrl()).isNull();
     }
 


### PR DESCRIPTION
## 문제 정의

> 지역 관련 정보를 HomeService에서 완전히 관리하게 한 후, extra info에서 추가적인 지역 관련 정보를 주입하지 않는다. (migrate API 사용)

#90 2안 적용

## DONE

* 이사 API만을 사용해서 거주 행정구역을 선택할 수 있게 함.
* 프론트엔드 호환성을 위해서 DTO에서는 필드를 제거하지 않음.