### PR TITLE
AuthOnly 어노테이션 작성, AOP로 인증 핸들링

### DIFF
--- a/src/main/java/com/techeer/f5/jmtmonster/domain/home/controller/HomeController.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/home/controller/HomeController.java
@@ -1,20 +1,17 @@
 package com.techeer.f5.jmtmonster.domain.home.controller;
 
 import com.techeer.f5.jmtmonster.domain.home.dto.HomeHistoriesDto;
-import com.techeer.f5.jmtmonster.domain.home.dto.HomeHistoryDto;
 import com.techeer.f5.jmtmonster.domain.home.dto.HomeRequestDto;
 import com.techeer.f5.jmtmonster.domain.home.dto.HomeResponseDto;
 import com.techeer.f5.jmtmonster.domain.home.service.HomeService;
+import com.techeer.f5.jmtmonster.domain.oauth.aop.annotation.AuthOnly;
 import com.techeer.f5.jmtmonster.domain.user.domain.User;
 import com.techeer.f5.jmtmonster.domain.user.service.UserService;
-import com.techeer.f5.jmtmonster.global.error.exception.ResourceNotFoundException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 
 @RestController
@@ -26,17 +23,9 @@ public class HomeController {
     private final HomeService homeService;
 
     @GetMapping
+    @AuthOnly
     public ResponseEntity<HomeResponseDto> getHome(HttpServletRequest request) {
-        User user = null;
-
-        try {
-            user = userService.findUserWithRequest(request);
-        } catch (ResourceNotFoundException exception) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                                    .body(HomeResponseDto.builder()
-                                                            .name(null)
-                                                            .code(null).build());
-        }
+        User user = userService.findUserWithRequest(request);
 
         HomeResponseDto dto = homeService.findHomeByUser(user);
 
@@ -44,35 +33,20 @@ public class HomeController {
     }
 
     @GetMapping("/history")
+    @AuthOnly
     public ResponseEntity<HomeHistoriesDto> getHistory(HttpServletRequest request) {
-        User user = null;
-
-        try {
-            user = userService.findUserWithRequest(request);
-        } catch (ResourceNotFoundException exception) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(HomeHistoriesDto.builder().build());
-        }
-
+        User user = userService.findUserWithRequest(request);
         HomeHistoriesDto historiesDto = homeService.getHomeHistory(user);
 
         return ResponseEntity.ok(historiesDto);
     }
 
     @PutMapping
+    @AuthOnly
     public ResponseEntity<HomeResponseDto> migrate(HttpServletRequest request, @Valid @RequestBody HomeRequestDto homeRequestDto) {
-        User user = null;
-
-        try {
-            user = userService.findUserWithRequest(request);
-        } catch (ResourceNotFoundException exception) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(HomeResponseDto.builder()
-                            .name(null)
-                            .code(null).build());
-        }
-
+        User user = userService.findUserWithRequest(request);
         HomeResponseDto homeResponseDto = homeService.migrate(user, homeRequestDto);
+
         return ResponseEntity.ok(homeResponseDto);
     }
 }

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/oauth/aop/annotation/AuthOnly.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/oauth/aop/annotation/AuthOnly.java
@@ -1,0 +1,11 @@
+package com.techeer.f5.jmtmonster.domain.oauth.aop.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthOnly {
+}

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/oauth/aop/aspect/AuthAspect.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/oauth/aop/aspect/AuthAspect.java
@@ -1,0 +1,72 @@
+package com.techeer.f5.jmtmonster.domain.oauth.aop.aspect;
+
+import com.techeer.f5.jmtmonster.domain.oauth.domain.PersistentToken;
+import com.techeer.f5.jmtmonster.domain.oauth.repository.PersistentTokenRepository;
+import com.techeer.f5.jmtmonster.global.error.ErrorResponse;
+import com.techeer.f5.jmtmonster.global.error.exception.ErrorCode;
+import com.techeer.f5.jmtmonster.global.error.exception.NotAuthorizedException;
+import com.techeer.f5.jmtmonster.global.utils.JsonMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AuthAspect {
+
+    private final HttpServletRequest request;
+    private final HttpServletResponse response;
+    private final PersistentTokenRepository persistentTokenRepository;
+    private final JsonMapper jsonMapper;
+
+    @Pointcut("@annotation(com.techeer.f5.jmtmonster.domain.oauth.aop.annotation.AuthOnly)")
+    private void checkAuth() {
+    }
+
+    private void sendErrorResponse(String message) {
+        NotAuthorizedException ex = new NotAuthorizedException(message);
+        ErrorResponse errorResponse = ErrorResponse.of(ex.getCode(), ex.getMessage());
+
+        response.setStatus(ex.getCode().getStatus().value());
+        response.setContentType("application/json");
+
+        String result = jsonMapper.asJsonString(errorResponse);
+
+        try {
+            response.getWriter().write(result);
+        } catch (IOException ignored) {
+            log.error("Failed to set error response because of IOException");
+        }
+    }
+
+    @Before("checkAuth()")
+    private void checkAuthBefore(JoinPoint joinPoint) {
+        String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        UUID token;
+
+        try {
+            token = UUID.fromString(authorizationHeader.substring("Bearer ".length()));
+        } catch (IllegalArgumentException | IndexOutOfBoundsException e) {
+            sendErrorResponse("Failed to parse authorization header bearer token");
+            return;
+        }
+
+        if (persistentTokenRepository.findById(token).isEmpty()) {
+            sendErrorResponse("Token is not valid");
+        }
+
+    }
+}

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/review/dao/ReviewQueryRepositoryImpl.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/review/dao/ReviewQueryRepositoryImpl.java
@@ -23,6 +23,7 @@ public class ReviewQueryRepositoryImpl implements ReviewQueryRepository {
         List<Review> result = jpaQueryFactory.selectFrom(QReview.review)
             .where(QReview.review.user.id.eq(userId))
             .limit(pageable.getPageSize())
+            .offset(pageable.getOffset())
             .fetch();
 
         int total = result.size();

--- a/src/main/java/com/techeer/f5/jmtmonster/domain/user/controller/UserController.java
+++ b/src/main/java/com/techeer/f5/jmtmonster/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.techeer.f5.jmtmonster.domain.user.controller;
 
+import com.techeer.f5.jmtmonster.domain.oauth.aop.annotation.AuthOnly;
 import com.techeer.f5.jmtmonster.domain.user.dto.UserDto;
 import com.techeer.f5.jmtmonster.domain.user.dto.UserResponseDto;
 import com.techeer.f5.jmtmonster.domain.user.dto.ExtraUserInfoRequestDto;
@@ -25,33 +26,22 @@ public class UserController {
     private final UserService userService;
 
     @GetMapping("/me")
+    @AuthOnly
     public ResponseEntity<UserResponseDto> getMyUser(HttpServletRequest request) {
         UserResponseDto userResponseDto = userService.getMyUser(request);
 
         return ResponseEntity.status(HttpStatus.OK)
-                .body(userResponseDto);
+            .body(userResponseDto);
     }
 
     @PostMapping("/me/extra-info")
     @PutMapping("/me/extra-info")
+    @AuthOnly
     public ResponseEntity<UserResponseDto> submitExtraInfo(HttpServletRequest request, @RequestBody @Valid ExtraUserInfoRequestDto extraUserInfoRequestDto) {
-        try {
-            UserResponseDto userResponseDto = userService.submitExtraInfo(request, extraUserInfoRequestDto);
+        UserResponseDto userResponseDto = userService.submitExtraInfo(request, extraUserInfoRequestDto);
 
-            return ResponseEntity.status(HttpStatus.OK)
-                    .body(userResponseDto);
-        } catch (NotAuthorizedException |
-                 ResourceNotFoundException |
-                 RollbackException |
-                 TransactionSystemException exception) {
-            log.error(exception.toString());
-        }
-
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(UserResponseDto.builder()
-                        .isSuccess(false)
-                        .user(UserDto.builder().id(null).build())
-                        .build());
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(userResponseDto);
     }
 
 }

--- a/src/test/java/com/techeer/f5/jmtmonster/domain/user/UserControllerTest.java
+++ b/src/test/java/com/techeer/f5/jmtmonster/domain/user/UserControllerTest.java
@@ -22,6 +22,8 @@ import com.techeer.f5.jmtmonster.domain.user.dto.UserResponseDto;
 import com.techeer.f5.jmtmonster.domain.user.repository.UserRepository;
 import com.techeer.f5.jmtmonster.domain.user.service.UserService;
 import com.techeer.f5.jmtmonster.global.utils.JsonMapper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,6 +31,7 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
@@ -37,6 +40,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
@@ -76,58 +81,58 @@ public class UserControllerTest {
         PersistentToken persistentToken = persistentTokenRepository.build(user, AuthProvider.KAKAO);
 
         MvcResult mvcResult = mockMvc.perform(RestDocumentationRequestBuilders.get("/users/me")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + persistentToken.getId().toString())
-                        .accept(MediaType.APPLICATION_JSON))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andDo(MockMvcRestDocumentationWrapper.document("my-user",
-                        preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint()),
-                        resource(
-                                ResourceSnippetParameters.builder()
-                                        .description("현재 사용자를 가져옵니다.")
-                                        .summary("현재 사용자 조회")
-                                        .requestHeaders(
-                                                headerWithName(
-                                                        HttpHeaders.AUTHORIZATION).description(
-                                                        "Bearer 사용자 토큰")
-                                        )
-                                        .responseFields(
-                                                fieldWithPath("isSuccess").type(
-                                                        JsonFieldType.BOOLEAN).description("성공 여부"),
-                                                fieldWithPath("user.id").type(JsonFieldType.STRING)
-                                                        .description("사용자 ID"),
-                                                fieldWithPath("user.name").type(
-                                                        JsonFieldType.STRING).description("사용자 이름"),
-                                                fieldWithPath("user.email").type(
-                                                                JsonFieldType.STRING)
-                                                        .description("사용자 이메일"),
-                                                fieldWithPath("user.nickname").type(
-                                                                JsonFieldType.STRING).optional()
-                                                        .description("사용자 닉네임"),
-                                                fieldWithPath("user.address").type(
-                                                                JsonFieldType.STRING).optional()
-                                                        .description("사용자 주소"),
-                                                fieldWithPath("user.imageUrl").type(
-                                                                JsonFieldType.STRING).optional()
-                                                        .description("사용자 이미지 URL"),
-                                                fieldWithPath("user.emailVerified").type(
-                                                                JsonFieldType.BOOLEAN)
-                                                        .description("사용자 이메일 인증 여부"),
-                                                fieldWithPath("user.extraInfoInjected").type(
-                                                                JsonFieldType.BOOLEAN)
-                                                        .description("사용자 추가 정보 입력 여부"),
-                                                fieldWithPath("user.verified").type(
-                                                        JsonFieldType.BOOLEAN).description(
-                                                        "사용자 인증 여부 (emailVerified && extraInfoInjected)")
-                                        )
-                                        .build()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + persistentToken.getId().toString())
+                .accept(MediaType.APPLICATION_JSON))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andDo(MockMvcRestDocumentationWrapper.document("my-user",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                resource(
+                    ResourceSnippetParameters.builder()
+                        .description("현재 사용자를 가져옵니다.")
+                        .summary("현재 사용자 조회")
+                        .requestHeaders(
+                            headerWithName(
+                                HttpHeaders.AUTHORIZATION).description(
+                                "Bearer 사용자 토큰")
                         )
-                ))
-                .andReturn();
+                        .responseFields(
+                            fieldWithPath("isSuccess").type(
+                                JsonFieldType.BOOLEAN).description("성공 여부"),
+                            fieldWithPath("user.id").type(JsonFieldType.STRING)
+                                .description("사용자 ID"),
+                            fieldWithPath("user.name").type(
+                                JsonFieldType.STRING).description("사용자 이름"),
+                            fieldWithPath("user.email").type(
+                                    JsonFieldType.STRING)
+                                .description("사용자 이메일"),
+                            fieldWithPath("user.nickname").type(
+                                    JsonFieldType.STRING).optional()
+                                .description("사용자 닉네임"),
+                            fieldWithPath("user.address").type(
+                                    JsonFieldType.STRING).optional()
+                                .description("사용자 주소"),
+                            fieldWithPath("user.imageUrl").type(
+                                    JsonFieldType.STRING).optional()
+                                .description("사용자 이미지 URL"),
+                            fieldWithPath("user.emailVerified").type(
+                                    JsonFieldType.BOOLEAN)
+                                .description("사용자 이메일 인증 여부"),
+                            fieldWithPath("user.extraInfoInjected").type(
+                                    JsonFieldType.BOOLEAN)
+                                .description("사용자 추가 정보 입력 여부"),
+                            fieldWithPath("user.verified").type(
+                                JsonFieldType.BOOLEAN).description(
+                                "사용자 인증 여부 (emailVerified && extraInfoInjected)")
+                        )
+                        .build()
+                )
+            ))
+            .andReturn();
 
         UserResponseDto userResponseDto = jsonMapper.fromMvcResult(mvcResult,
-                UserResponseDto.class);
+            UserResponseDto.class);
 
         assertThat(userResponseDto.getIsSuccess()).isTrue();
         assertThat(userResponseDto.getUser()).isNotNull();
@@ -149,68 +154,68 @@ public class UserControllerTest {
         assertThat(user.getVerified()).isFalse();
 
         ExtraUserInfoRequestDto extraUserInfoRequestDto = ExtraUserInfoRequestDto.builder()
-                .nickname("DPS0340")
-                .address("경기도 시흥시 서울대학로278번길 19-13")
-                .imageUrl(null)
-                .build();
+            .nickname("DPS0340")
+            .address("경기도 시흥시 서울대학로278번길 19-13")
+            .imageUrl(null)
+            .build();
 
         MvcResult mvcResult = mockMvc.perform(
-                        RestDocumentationRequestBuilders.post("/users/me/extra-info")
-                                .header(HttpHeaders.AUTHORIZATION,
-                                        "Bearer " + persistentToken.getId().toString())
-                                .content(jsonMapper.asJsonString(extraUserInfoRequestDto))
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .accept(MediaType.APPLICATION_JSON))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andDo(MockMvcRestDocumentationWrapper.document("submit-extra-info",
-                        preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint()),
-                        resource(
-                                ResourceSnippetParameters.builder()
-                                        .description("추가 정보를 입력합니다.")
-                                        .summary("추가 정보 입력")
-                                        .requestHeaders(
-                                                headerWithName(
-                                                        HttpHeaders.AUTHORIZATION).description(
-                                                        "Bearer 사용자 토큰")
-                                        )
-                                        .responseFields(
-                                                fieldWithPath("isSuccess").type(
-                                                        JsonFieldType.BOOLEAN).description("성공 여부"),
-                                                fieldWithPath("user.id").type(JsonFieldType.STRING)
-                                                        .description("사용자 ID"),
-                                                fieldWithPath("user.name").type(
-                                                        JsonFieldType.STRING).description("사용자 이름"),
-                                                fieldWithPath("user.email").type(
-                                                                JsonFieldType.STRING)
-                                                        .description("사용자 이메일"),
-                                                fieldWithPath("user.nickname").type(
-                                                                JsonFieldType.STRING).optional()
-                                                        .description("사용자 닉네임"),
-                                                fieldWithPath("user.address").type(
-                                                                JsonFieldType.STRING).optional()
-                                                        .description("사용자 주소"),
-                                                fieldWithPath("user.imageUrl").type(
-                                                                JsonFieldType.STRING).optional()
-                                                        .description("사용자 이미지 URL"),
-                                                fieldWithPath("user.emailVerified").type(
-                                                                JsonFieldType.BOOLEAN)
-                                                        .description("사용자 이메일 인증 여부"),
-                                                fieldWithPath("user.extraInfoInjected").type(
-                                                                JsonFieldType.BOOLEAN)
-                                                        .description("사용자 추가 정보 입력 여부"),
-                                                fieldWithPath("user.verified").type(
-                                                        JsonFieldType.BOOLEAN).description(
-                                                        "사용자 인증 여부 (emailVerified && extraInfoInjected)")
-                                        )
-                                        .build()
+                RestDocumentationRequestBuilders.post("/users/me/extra-info")
+                    .header(HttpHeaders.AUTHORIZATION,
+                        "Bearer " + persistentToken.getId().toString())
+                    .content(jsonMapper.asJsonString(extraUserInfoRequestDto))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andDo(MockMvcRestDocumentationWrapper.document("submit-extra-info",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                resource(
+                    ResourceSnippetParameters.builder()
+                        .description("추가 정보를 입력합니다.")
+                        .summary("추가 정보 입력")
+                        .requestHeaders(
+                            headerWithName(
+                                HttpHeaders.AUTHORIZATION).description(
+                                "Bearer 사용자 토큰")
                         )
-                ))
-                .andReturn();
+                        .responseFields(
+                            fieldWithPath("isSuccess").type(
+                                JsonFieldType.BOOLEAN).description("성공 여부"),
+                            fieldWithPath("user.id").type(JsonFieldType.STRING)
+                                .description("사용자 ID"),
+                            fieldWithPath("user.name").type(
+                                JsonFieldType.STRING).description("사용자 이름"),
+                            fieldWithPath("user.email").type(
+                                    JsonFieldType.STRING)
+                                .description("사용자 이메일"),
+                            fieldWithPath("user.nickname").type(
+                                    JsonFieldType.STRING).optional()
+                                .description("사용자 닉네임"),
+                            fieldWithPath("user.address").type(
+                                    JsonFieldType.STRING).optional()
+                                .description("사용자 주소"),
+                            fieldWithPath("user.imageUrl").type(
+                                    JsonFieldType.STRING).optional()
+                                .description("사용자 이미지 URL"),
+                            fieldWithPath("user.emailVerified").type(
+                                    JsonFieldType.BOOLEAN)
+                                .description("사용자 이메일 인증 여부"),
+                            fieldWithPath("user.extraInfoInjected").type(
+                                    JsonFieldType.BOOLEAN)
+                                .description("사용자 추가 정보 입력 여부"),
+                            fieldWithPath("user.verified").type(
+                                JsonFieldType.BOOLEAN).description(
+                                "사용자 인증 여부 (emailVerified && extraInfoInjected)")
+                        )
+                        .build()
+                )
+            ))
+            .andReturn();
 
         UserResponseDto userResponseDto = jsonMapper.fromMvcResult(mvcResult,
-                UserResponseDto.class);
+            UserResponseDto.class);
 
         assertThat(userResponseDto.getIsSuccess()).isTrue();
         assertThat(userResponseDto.getUser()).isNotNull();
@@ -220,6 +225,29 @@ public class UserControllerTest {
         assertThat(userResponseDto.getUser().getNickname()).isEqualTo("DPS0340");
         assertThat(userResponseDto.getUser().getAddress()).isEqualTo("경기도 시흥시 서울대학로278번길 19-13");
         assertThat(userResponseDto.getUser().getImageUrl()).isNull();
+    }
+
+    @Test
+    @DisplayName("등록되지 않은 토큰으로 /users/me API 사용 시 401")
+    public void testMyInfoWithNotRegisteredToken() throws Exception {
+        UUID dummyToken = UUID.randomUUID();
+        mockMvc.perform(
+                RestDocumentationRequestBuilders.get("/users/me")
+                    .header(HttpHeaders.AUTHORIZATION,
+                        "Bearer " + dummyToken.toString())
+                    .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().is(HttpStatus.UNAUTHORIZED.value()));
+
+    }
+
+    @Test
+    @DisplayName("토큰 없이 /users/me API 사용 시 401")
+    public void testMyInfoWithoutAuthorization() throws Exception {
+        mockMvc.perform(
+                RestDocumentationRequestBuilders.get("/users/me")
+                    .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().is(HttpStatus.UNAUTHORIZED.value()));
+
     }
 
 }


### PR DESCRIPTION
## 문제 정의

Spring AOP 기반으로 인증 로직을 분리시켜 인증 코드의 재사용성과 편의성을 향상시킴.

## DONE

* AuthOnly 어노테이션 작성
* AuthAspect 클래스 Aspect 작성
* 중복되는 컨트롤러단 유저 체크 후 401 리턴 로직 삭제
* UserController에서 AOP를 활용한 /users/me 인증 실패시 401 테스트